### PR TITLE
V1.6.1

### DIFF
--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -1739,13 +1739,13 @@
 					"response": []
 				},
 				{
-					"name": "getTx",
+					"name": "getAtomicTx",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avax.getTx\",\n    \"params\" :{\n        \"txID\":\"2LVVdbsbg7Lkp3bVBzbJeopp8HfBMApefoHLZ7VaFkXPPvd7KJ\"\n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avax.getAtomicTx\",\n    \"params\" :{\n        \"txID\":\"n1D9UkjiryEBtW8qznD1TDkGEuYRFj5tLaS8NhVpMLYsx1FHa\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1777,7 +1777,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"id\": 1,\n    \"method\": \"avax.getAtomicTxStatus\",\n    \"params\": {\n        \"txID\": \"2LVVdbsbg7Lkp3bVBzbJeopp8HfBMApefoHLZ7VaFkXPPvd7KJ\"\n    }\n}",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"id\": 1,\n    \"method\": \"avax.getAtomicTxStatus\",\n    \"params\": {\n        \"txID\": \"n1D9UkjiryEBtW8qznD1TDkGEuYRFj5tLaS8NhVpMLYsx1FHa\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"

--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -474,7 +474,7 @@
 								"X"
 							]
 						},
-						"description": "Send AVAX from the X-Chain to an account on the P-Chain.\nAfter calling this method, you must call the P-Chain’s `importAVAX` method to complete the transfer. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmexportavax)"
+						"description": "Export AVAX from both the X-Chain to the P-Chain as well as from the X-Chain to the C-Chain.\nAfter calling this method, you must call either the P-Chain’s `importAVAX` method or the C-Chain's `importAVAX` method to complete the transfer. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmexportavax)"
 					},
 					"response": []
 				},
@@ -485,7 +485,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.exportKey\",\n    \"params\" :{\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"address\": \"X-local1xnkhvsqu2w5h8gwc7k3hl7xcxuwhmaksm4s2d8\"\n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.exportKey\",\n    \"params\" :{\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"address\": \"{{xchainAddress}}\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -516,7 +516,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.getAllBalances\",\n    \"params\" :{\n        \"address\":\"X-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u\"\n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.getAllBalances\",\n    \"params\" :{\n        \"address\":\"{{xchainAddress}}\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -702,7 +702,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.getUTXOs\",\n    \"params\" :{\n        \"addresses\":[\"X-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u\"],\n        \"limit\": 5\n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.getUTXOs\",\n    \"params\" :{\n        \"addresses\":[\"{{xchainAddress}}\"],\n        \"limit\": 5\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -753,7 +753,7 @@
 								"X"
 							]
 						},
-						"description": "Finalize a transfer of AVAX from the P-Chain to the X-Chain.\n\nBefore this method is called, you must call the P-Chain’s `exportAVAX` method to initiate the transfer. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmimportavax)"
+						"description": "Finalize a transfer of AVAX from either the P-Chain to the X-Chain or the C-Chain to the X-Chain.\n\nBefore this method is called, you must call either the P-Chain’s `exportAVAX` method or the C-Chain’s `exportAVAX` method to initiate the transfer. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmimportavax)"
 					},
 					"response": []
 				},
@@ -919,7 +919,38 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.send\",\n    \"params\" :{ \n        \"assetID\" : \"{{avaxAssetId}}\",\n        \"amount\"  : 10000,\n        \"from\"    : [\"{{xchainAddress}}\"],\n        \"to\"      : \"{{xchainAddress}}\",\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\" \n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.send\",\n    \"params\" :{ \n        \"assetID\" : \"{{avaxAssetId}}\",\n        \"amount\"  : 2000000,\n        \"from\"    : [\"{{xchainAddress}}\"],\n        \"to\"      : \"X-avax1g8u6w6jnnwd8p280q38wwrwkr357pzq3asspdz\",\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"memo\"    : \"{{memo}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\" \n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/X",
+							"protocol": "{{http}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"bc",
+								"X"
+							]
+						},
+						"description": "Send a quantity of an asset to an address. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmsend)"
+					},
+					"response": []
+				},
+				{
+					"name": "sendMultiple",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.sendMultiple\",\n    \"params\" :{ \n        \"outputs\": [\n            {\n                \"assetID\" : \"{{avaxAssetId}}\",\n                \"to\"      : \"{{xchainAddress}}\",\n                \"amount\"  : 1000000000\n            }\n        ],\n        \"from\"    : [\"{{xchainAddress}}\"],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"memo\"    : \"{{memo}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\" \n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -2553,7 +2584,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.getCurrentValidators\",\n    \"params\": {\n        \"subnetID\": \"j87H8JFHc3wWQ8FQ3P8gGyu9UHdPcz3BcqNTvJKUG6AJ6DDpF\"\n    },\n    \"id\": 1\n}",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.getCurrentValidators\",\n    \"params\": {\n        \"subnetID\": \"{{customSubnetID}}\"\n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -2883,7 +2914,7 @@
 								"P"
 							]
 						},
-						"description": "Send AVAX from an account on the P-Chain to an address on the X-Chain.\nThis transaction must be signed with the key of the account that the AVAX is sent from and which pays the transaction fee.\nAfter issuing this transaction, you must call the X-Chain’s `importAVA` method to complete the transfer. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformexportavax)"
+						"description": "Send AVAX from an account on the C-Chain to an address on the X-Chain.\nThis transaction must be signed with the key of the account that the AVAX is sent from and which pays the transaction fee.\nAfter issuing this transaction, you must call the X-Chain’s `importAVA` method to complete the transfer. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformexportavax)"
 					},
 					"response": []
 				},
@@ -2945,7 +2976,7 @@
 								"P"
 							]
 						},
-						"description": "Complete a transfer of AVAX from the X-Chain to the P-Chain.\n\nBefore this method is called, you must call the X-Chain’s `exportAVAX` method to initiate the transfer. [More Info](https://docs.avax.network/v1.0/en/api/platform/#avmimportava)"
+						"description": "Complete a transfer of AVAX from the X-Chain to the C-Chain.\n\nBefore this method is called, you must call the X-Chain’s `exportAVAX` method to initiate the transfer. [More Info](https://docs.avax.network/v1.0/en/api/platform/#avmimportava)"
 					},
 					"response": []
 				},

--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -338,7 +338,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/X",
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/X",
 							"protocol": "{{http}}",
 							"host": [
 								"{{host}}"
@@ -346,6 +346,7 @@
 							"port": "{{port}}",
 							"path": [
 								"ext",
+								"bc",
 								"X"
 							]
 						},
@@ -368,7 +369,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/X",
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/X",
 							"protocol": "{{http}}",
 							"host": [
 								"{{host}}"
@@ -376,40 +377,11 @@
 							"port": "{{port}}",
 							"path": [
 								"ext",
+								"bc",
 								"X"
 							]
 						},
 						"description": "Create a new fixed-cap, fungible asset. A quantity of it is created at initialization and then no more is ever created. The asset can be sent with `avm.send`. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmcreatefixedcapasset)"
-					},
-					"response": []
-				},
-				{
-					"name": "createMintTx",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.mint\",\n    \"params\" :{\n        \"amount\": 10000000,\n        \"assetID\": \"2qnR9pLQTDZ9boSbcrcjS4n1DJJkzbkNsJzgwYvmRy8uv47fZT\",\n        \"from\": [\"{{xchainAddress}}\"],\n        \"to\": \"{{xchainAddress}}\",\n        \"minters\": [\n            \"{{xchainAddress}}\"\n        ],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\" \n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/X",
-							"protocol": "{{http}}",
-							"host": [
-								"{{host}}"
-							],
-							"port": "{{port}}",
-							"path": [
-								"ext",
-								"X"
-							]
-						},
-						"description": "Create an unsigned transaction to mint more of a variable-cap asset (an asset created with `avm.createVariableCapAsset`.) [More info](https://docs.avax.network/v1.0/en/api/avm/#avmcreateminttx)"
 					},
 					"response": []
 				},
@@ -420,7 +392,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.createNFTAsset\",\n    \"params\" :{\n        \"name\":\"Coincert\",\n        \"symbol\":\"TIXX\",\n        \"minterSets\":[\n            {\n                \"minters\":[\n                    \"{{xchainAddress}}\"\n                ],\n                \"threshold\": 1\n            }\n        ],\n        \"from\": [\"{{xchainAddress}}\"],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.createNFTAsset\",\n    \"params\" :{\n        \"name\":\"Coincert\",\n        \"symbol\":\"TIXX\",\n        \"minterSets\":[\n            {\n                \"minters\":[\n                    \"{{xchainAddress}}\"\n                ],\n                \"threshold\": 1\n            },\n            {\n                \"minters\":[\n                    \"{{xchainAddress}}\"\n                ],\n                \"threshold\": 1\n            }\n        ],\n        \"from\": [\"{{xchainAddress}}\"],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -428,7 +400,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/X",
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/X",
 							"protocol": "{{http}}",
 							"host": [
 								"{{host}}"
@@ -436,6 +408,7 @@
 							"port": "{{port}}",
 							"path": [
 								"ext",
+								"bc",
 								"X"
 							]
 						},
@@ -458,7 +431,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/X",
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/X",
 							"protocol": "{{http}}",
 							"host": [
 								"{{host}}"
@@ -466,6 +439,7 @@
 							"port": "{{port}}",
 							"path": [
 								"ext",
+								"bc",
 								"X"
 							]
 						},
@@ -488,7 +462,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/X",
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/X",
 							"protocol": "{{http}}",
 							"host": [
 								"{{host}}"
@@ -496,6 +470,7 @@
 							"port": "{{port}}",
 							"path": [
 								"ext",
+								"bc",
 								"X"
 							]
 						},
@@ -510,7 +485,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.exportKey\",\n    \"params\" :{\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"address\": \"{{xchainAddress}}\"\n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.exportKey\",\n    \"params\" :{\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"address\": \"X-local1xnkhvsqu2w5h8gwc7k3hl7xcxuwhmaksm4s2d8\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -518,7 +493,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/X",
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/X",
 							"protocol": "{{http}}",
 							"host": [
 								"{{host}}"
@@ -526,6 +501,7 @@
 							"port": "{{port}}",
 							"path": [
 								"ext",
+								"bc",
 								"X"
 							]
 						},
@@ -540,7 +516,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.getAllBalances\",\n    \"params\" :{\n        \"address\":\"{{xchainAddress}}\"\n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.getAllBalances\",\n    \"params\" :{\n        \"address\":\"X-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -548,7 +524,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/X",
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/X",
 							"protocol": "{{http}}",
 							"host": [
 								"{{host}}"
@@ -556,6 +532,7 @@
 							"port": "{{port}}",
 							"path": [
 								"ext",
+								"bc",
 								"X"
 							]
 						},
@@ -578,7 +555,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/X",
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/X",
 							"protocol": "{{http}}",
 							"host": [
 								"{{host}}"
@@ -586,6 +563,7 @@
 							"port": "{{port}}",
 							"path": [
 								"ext",
+								"bc",
 								"X"
 							]
 						},
@@ -670,7 +648,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/X",
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/X",
 							"protocol": "{{http}}",
 							"host": [
 								"{{host}}"
@@ -678,6 +656,7 @@
 							"port": "{{port}}",
 							"path": [
 								"ext",
+								"bc",
 								"X"
 							]
 						},
@@ -692,7 +671,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.getTxStatus\",\n    \"params\" :{\n        \"txID\":\"3K4aPCTZVZwjWk44fEkdbESzRWoFAbZCRSSpcFouGGH2g1XUf\"\n    }\n}",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"id\": 1,\n    \"method\": \"avm.getTxStatus\",\n    \"params\": {\n        \"txID\": \"2HHr7xUJgWiLESV7g8T3oWfWvdpWJXd4Hctj6U3KhzUN6EsgBG\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -700,7 +679,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/X",
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/X",
 							"protocol": "{{http}}",
 							"host": [
 								"{{host}}"
@@ -708,6 +687,7 @@
 							"port": "{{port}}",
 							"path": [
 								"ext",
+								"bc",
 								"X"
 							]
 						},
@@ -722,7 +702,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.getUTXOs\",\n    \"params\" :{\n        \"addresses\":[\"{{xchainAddress}}\"],\n        \"limit\": 5\n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.getUTXOs\",\n    \"params\" :{\n        \"addresses\":[\"X-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u\"],\n        \"limit\": 5\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -730,7 +710,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/X",
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/X",
 							"protocol": "{{http}}",
 							"host": [
 								"{{host}}"
@@ -738,6 +718,7 @@
 							"port": "{{port}}",
 							"path": [
 								"ext",
+								"bc",
 								"X"
 							]
 						},
@@ -760,7 +741,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/X",
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/X",
 							"protocol": "{{http}}",
 							"host": [
 								"{{host}}"
@@ -768,6 +749,7 @@
 							"port": "{{port}}",
 							"path": [
 								"ext",
+								"bc",
 								"X"
 							]
 						},
@@ -821,7 +803,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/X",
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/X",
 							"protocol": "{{http}}",
 							"host": [
 								"{{host}}"
@@ -829,6 +811,7 @@
 							"port": "{{port}}",
 							"path": [
 								"ext",
+								"bc",
 								"X"
 							]
 						},
@@ -851,7 +834,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/X",
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/X",
 							"protocol": "{{http}}",
 							"host": [
 								"{{host}}"
@@ -859,10 +842,42 @@
 							"port": "{{port}}",
 							"path": [
 								"ext",
+								"bc",
 								"X"
 							]
 						},
 						"description": "List addresses controlled by the given user. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmlistaddresses)"
+					},
+					"response": []
+				},
+				{
+					"name": "mint",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.mint\",\n    \"params\" :{\n        \"amount\": 10000000,\n        \"assetID\": \"2qnR9pLQTDZ9boSbcrcjS4n1DJJkzbkNsJzgwYvmRy8uv47fZT\",\n        \"from\": [\"{{xchainAddress}}\"],\n        \"to\": \"{{xchainAddress}}\",\n        \"minters\": [\n            \"{{xchainAddress}}\"\n        ],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\" \n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/X",
+							"protocol": "{{http}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"bc",
+								"X"
+							]
+						},
+						"description": "Create an unsigned transaction to mint more of a variable-cap asset (an asset created with `avm.createVariableCapAsset`.) [More info](https://docs.avax.network/v1.0/en/api/avm/#avmcreateminttx)"
 					},
 					"response": []
 				},
@@ -873,7 +888,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.mintNFT\",\n    \"params\" :{\n        \"amount\":1,\n        \"assetID\":\"7ifkSF7D2heHgF7owoWQgzDV4fDzneqWJ9B4qa7peMPE8foBf\",\n        \"payload\":\"2EWh72jYQvEJF9NLk\",\n        \"from\": [\"{{xchainAddress}}\"],\n        \"to\":\"{{xchainAddress}}\",\n        \"minters\":[\n            \"X-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u\"\n        ],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.mintNFT\",\n    \"params\" :{\n        \"assetID\":\"2KGdt2HpFKpTH5CtGZjYt5XPWs6Pv9DLoRBhiFfntbezdRvZWP\",\n        \"payload\":\"2EWh72jYQvEJF9NLk\",\n        \"from\": [\"{{xchainAddress}}\"],\n        \"to\":\"{{xchainAddress}}\",\n        \"minters\":[\n            \"{{xchainAddress}}\"\n        ],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -881,7 +896,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/X",
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/X",
 							"protocol": "{{http}}",
 							"host": [
 								"{{host}}"
@@ -889,6 +904,7 @@
 							"port": "{{port}}",
 							"path": [
 								"ext",
+								"bc",
 								"X"
 							]
 						},
@@ -911,7 +927,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/X",
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/X",
 							"protocol": "{{http}}",
 							"host": [
 								"{{host}}"
@@ -919,6 +935,7 @@
 							"port": "{{port}}",
 							"path": [
 								"ext",
+								"bc",
 								"X"
 							]
 						},
@@ -933,7 +950,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.sendNFT\",\n    \"params\" :{ \n        \"assetID\" :\"2Y1VBSy8WX5T7f7ifMPpjm8jbFWYvVv1iSQefhAcpwokhk2GXX\",\n        \"from\"    : [\"{{xchainAddress}}\"],\n        \"to\"      :\"{{xchainAddress}}\",\n        \"groupID\" : 0,\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.sendNFT\",\n    \"params\" :{ \n        \"assetID\" :\"2KGdt2HpFKpTH5CtGZjYt5XPWs6Pv9DLoRBhiFfntbezdRvZWP\",\n        \"from\"    : [\"{{xchainAddress}}\"],\n        \"to\"      :\"{{xchainAddress}}\",\n        \"groupID\" : 0,\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -941,7 +958,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/X",
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/X",
 							"protocol": "{{http}}",
 							"host": [
 								"{{host}}"
@@ -949,6 +966,7 @@
 							"port": "{{port}}",
 							"path": [
 								"ext",
+								"bc",
 								"X"
 							]
 						},
@@ -964,13 +982,13 @@
 			"name": "EVM",
 			"item": [
 				{
-					"name": "web3_clientVersion",
+					"name": "eth_blockNumber",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"web3_clientVersion\",\n    \"params\": [],\n    \"id\": 1\n}",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_blockNumber\",\n    \"params\": [],\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -991,18 +1009,18 @@
 								"rpc"
 							]
 						},
-						"description": "Getting the current client version. [More info](https://docs.avax.network/v1.0/en/api/evm/#getting-the-current-client-version)"
+						"description": "Getting the most recent block number. [More info](https://docs.avax.network/v1.0/en/api/evm/#getting-the-most-recent-block-number)"
 					},
 					"response": []
 				},
 				{
-					"name": "net_version",
+					"name": "eth_call",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"net_version\",\n    \"params\": [],\n    \"id\": 1\n}",
+							"raw": "{\n    \"id\": 1,\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_call\",\n    \"params\": [\n        {\n            \"to\": \"0x197E90f9FAD81970bA7976f33CbD77088E5D7cf7\",\n            \"data\": \"0xc92aecc4\"\n        },\n        \"latest\"\n    ]\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1023,7 +1041,7 @@
 								"rpc"
 							]
 						},
-						"description": "Getting the network ID. [More info](https://docs.avax.network/v1.0/en/api/evm/#getting-the-network-id)"
+						"description": "Call a contract. [More info](https://docs.avax.network/v1.0/en/api/evm/#call-a-contract)"
 					},
 					"response": []
 				},
@@ -1060,38 +1078,6 @@
 					"response": []
 				},
 				{
-					"name": "eth_blockNumber",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_blockNumber\",\n    \"params\": [],\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/rpc",
-							"protocol": "{{http}}",
-							"host": [
-								"{{host}}"
-							],
-							"port": "{{port}}",
-							"path": [
-								"ext",
-								"bc",
-								"C",
-								"rpc"
-							]
-						},
-						"description": "Getting the most recent block number. [More info](https://docs.avax.network/v1.0/en/api/evm/#getting-the-most-recent-block-number)"
-					},
-					"response": []
-				},
-				{
 					"name": "eth_getBalance",
 					"request": {
 						"method": "POST",
@@ -1120,6 +1106,38 @@
 							]
 						},
 						"description": "Getting an account’s balance. [More info](https://docs.avax.network/v1.0/en/api/evm/#getting-an-accounts-balance)"
+					},
+					"response": []
+				},
+				{
+					"name": "eth_signTransaction",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_signTransaction\",\n    \"params\": [{\n        \"from\": \"0xa64b27635c967dfe9674926bc004626163ddce97\",\n        \"to\": \"0x1c5b0e12e90e9c52235babad76cfccab2519bb95\",\n        \"gas\": \"0x5208\",\n        \"gasPrice\": \"0x0\",\n        \"nonce\": \"0x0\",\n        \"value\": \"0x0\"\n    }],\n    \"id\": 1\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/rpc",
+							"protocol": "{{http}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"bc",
+								"C",
+								"rpc"
+							]
+						},
+						"description": "Signing a transaction.\n\nThis method will create a signed transaction, but will not publish it automatically to the network. Instead, the `raw` result output should be used with `eth_sendRawTransaction` to execute the transaction. [More info](https://docs.avax.network/v1.0/en/api/evm/#signing-a-transaction)"
 					},
 					"response": []
 				},
@@ -1156,198 +1174,6 @@
 					"response": []
 				},
 				{
-					"name": "web3_sha3",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"web3_sha3\",\n    \"params\": [\n        \"0x736e6f7773746f726d\"\n    ],\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/rpc",
-							"protocol": "{{http}}",
-							"host": [
-								"{{host}}"
-							],
-							"port": "{{port}}",
-							"path": [
-								"ext",
-								"bc",
-								"C",
-								"rpc"
-							]
-						},
-						"description": "Calculate a cryptographic hash.\n\nThe input parameter contains hexidecimal bytes of arbitrary length. The example here uses the UTF-8 text string “snowstorm” converted to hexidecimal bytes. [More info](https://docs.avax.network/v1.0/en/api/evm/#calculate-a-cryptographic-hash)"
-					},
-					"response": []
-				},
-				{
-					"name": "personal_newAccount",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"personal_newAccount\",\n    \"params\": [\n        \"cheese\"\n    ],\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/rpc",
-							"protocol": "{{http}}",
-							"host": [
-								"{{host}}"
-							],
-							"port": "{{port}}",
-							"path": [
-								"ext",
-								"bc",
-								"C",
-								"rpc"
-							]
-						},
-						"description": "Creating a new account (private key generated automatically)\n\nThe EVM will create a new account using the passphrase `cheese` to encrypt and store the new account credentials. cheese is not the seed phrase and cannot be used to restore this account from scratch. Calling this function repeatedly with the same passphrase will create multiple unique accounts. Also keep in mind there are no options to export private keys stored in the EVM database. Users are encouraged to use wallet software instead for safer account creation and backup. This method is more suitable for quick account creation for a testnet."
-					},
-					"response": []
-				},
-				{
-					"name": "personal_importRawKey",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"personal_importRawKey\",\n    \"params\": [\n        \"627119bb8286874a15d562d32829613311a678da26ca7a6a785ec4ad85937d07\",\n        \"{{cchainPassphrase}}\"\n    ],\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/rpc",
-							"protocol": "{{http}}",
-							"host": [
-								"{{host}}"
-							],
-							"port": "{{port}}",
-							"path": [
-								"ext",
-								"bc",
-								"C",
-								"rpc"
-							]
-						},
-						"description": "Creating a new account (using plaintext private key).\n\nIf the private key is known upfront, it can be provided as plaintext to load into the EVM account database. For more secure account management, consider using wallet software instead. The example below loads the private key `0x627119bb8286874a15d562d32829613311a678da26ca7a6a785ec4ad85937d06` with the passphrase `this is my passphrase`. Note that `0x` prefix cannot be included in the private key argument, otherwise the EVM will throw an error. The example response returns the associated public key."
-					},
-					"response": []
-				},
-				{
-					"name": "personal_listAccounts",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"personal_listAccounts\",\n    \"params\": [],\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/rpc",
-							"protocol": "{{http}}",
-							"host": [
-								"{{host}}"
-							],
-							"port": "{{port}}",
-							"path": [
-								"ext",
-								"bc",
-								"C",
-								"rpc"
-							]
-						},
-						"description": "Listing accounts loaded in EVM node. [More info](https://docs.avax.network/v1.0/en/api/evm/#listing-accounts-loaded-in-evm-node)"
-					},
-					"response": []
-				},
-				{
-					"name": "personal_unlockAccount",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"personal_unlockAccount\",\n    \"params\": [\n        \"{{cchainAddress}}\",\n        \"{{cchainPassphrase}}\",\n        600\n    ],\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/rpc",
-							"protocol": "{{http}}",
-							"host": [
-								"{{host}}"
-							],
-							"port": "{{port}}",
-							"path": [
-								"ext",
-								"bc",
-								"C",
-								"rpc"
-							]
-						},
-						"description": "Unlocking an account.\n\nPersonal accounts loaded directly in the EVM can only sign transactions while in an unlocked state. The example below unlocks the listed account address for 60 seconds. Note the associated passphrase `cheese` must be provided for authorization. [More info](https://docs.avax.network/v1.0/en/api/evm/#unlocking-an-account)"
-					},
-					"response": []
-				},
-				{
-					"name": "eth_signTransaction",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_signTransaction\",\n    \"params\": [{\n        \"from\": \"0xa64b27635c967dfe9674926bc004626163ddce97\",\n        \"to\": \"0x1c5b0e12e90e9c52235babad76cfccab2519bb95\",\n        \"gas\": \"0x5208\",\n        \"gasPrice\": \"0x0\",\n        \"nonce\": \"0x0\",\n        \"value\": \"0x0\"\n    }],\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "http://localhost:9650/ext/bc/C/rpc",
-							"protocol": "http",
-							"host": [
-								"localhost"
-							],
-							"port": "9650",
-							"path": [
-								"ext",
-								"bc",
-								"C",
-								"rpc"
-							]
-						},
-						"description": "Signing a transaction.\n\nThis method will create a signed transaction, but will not publish it automatically to the network. Instead, the `raw` result output should be used with `eth_sendRawTransaction` to execute the transaction. [More info](https://docs.avax.network/v1.0/en/api/evm/#signing-a-transaction)"
-					},
-					"response": []
-				},
-				{
 					"name": "eth_sendRawTransaction",
 					"request": {
 						"method": "POST",
@@ -1376,38 +1202,6 @@
 							]
 						},
 						"description": "Send a raw transaction.\n\nExample below shows a raw transaction published to the network and its associated transaction hash. [More info](https://docs.avax.network/v1.0/en/api/evm/#send-a-raw-transaction)"
-					},
-					"response": []
-				},
-				{
-					"name": "eth_call",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"id\": 1,\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_call\",\n    \"params\": [\n        {\n            \"to\": \"0x197E90f9FAD81970bA7976f33CbD77088E5D7cf7\",\n            \"data\": \"0xc92aecc4\"\n        },\n        \"latest\"\n    ]\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/rpc",
-							"protocol": "{{http}}",
-							"host": [
-								"{{host}}"
-							],
-							"port": "{{port}}",
-							"path": [
-								"ext",
-								"bc",
-								"C",
-								"rpc"
-							]
-						},
-						"description": "Call a contract. [More info](https://docs.avax.network/v1.0/en/api/evm/#call-a-contract)"
 					},
 					"response": []
 				},
@@ -1540,6 +1334,294 @@
 					"response": []
 				},
 				{
+					"name": "exportAVAX",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"method\" :\"avax.exportAVAX\",\n    \"params\" :{\n        \"from\": [\"{{cchainAddress}}\"],\n        \"to\":\"{{xchainAddress}}\",\n        \"amount\": 4000001000000,\n        \"destinationChain\": \"X\",\n        \"changeAddr\": \"{{cchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    },\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/avax",
+							"protocol": "{{http}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"bc",
+								"C",
+								"avax"
+							]
+						},
+						"description": "Send AVAX from the X-Chain to an account on the P-Chain.\nAfter calling this method, you must call the P-Chain’s `importAVAX` method to complete the transfer. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmexportavax)"
+					},
+					"response": []
+				},
+				{
+					"name": "exportKey",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"method\" :\"avax.exportKey\",\n    \"params\" :{\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"address\": \"{{pchainAddress}}\"\n    },\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/avax",
+							"protocol": "{{http}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"bc",
+								"C",
+								"avax"
+							]
+						},
+						"description": "Get the private key that controls a given address.\nThe returned private key can be added to a user with `avm.importKey`. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmexportkey)\n\n"
+					},
+					"response": []
+				},
+				{
+					"name": "importAVAX",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"method\": \"avax.importAVAX\",\n    \"params\": {\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"sourceChain\": \"X\",\n        \"to\":\"{{cchainAddress}}\"\n    },\n    \"jsonrpc\": \"2.0\",\n    \"id\": 1\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/avax",
+							"protocol": "{{http}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"bc",
+								"C",
+								"avax"
+							]
+						},
+						"description": "Send AVAX from the X-Chain to an account on the P-Chain.\nAfter calling this method, you must call the P-Chain’s `importAVAX` method to complete the transfer. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmexportavax)"
+					},
+					"response": []
+				},
+				{
+					"name": "importKey",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"method\": \"avax.importKey\",\n    \"params\": {\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"privateKey\":\"{{privkey}}\"\n    },\n    \"jsonrpc\": \"2.0\",\n    \"id\": 1\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/avax",
+							"protocol": "{{http}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"bc",
+								"C",
+								"avax"
+							]
+						},
+						"description": "Give a user control over an address by providing the private key that controls the address. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmimportkey)"
+					},
+					"response": []
+				},
+				{
+					"name": "net_version",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"net_version\",\n    \"params\": [],\n    \"id\": 1\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/rpc",
+							"protocol": "{{http}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"bc",
+								"C",
+								"rpc"
+							]
+						},
+						"description": "Getting the network ID. [More info](https://docs.avax.network/v1.0/en/api/evm/#getting-the-network-id)"
+					},
+					"response": []
+				},
+				{
+					"name": "personal_newAccount",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"personal_newAccount\",\n    \"params\": [\n        \"cheese\"\n    ],\n    \"id\": 1\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/rpc",
+							"protocol": "{{http}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"bc",
+								"C",
+								"rpc"
+							]
+						},
+						"description": "Creating a new account (private key generated automatically)\n\nThe EVM will create a new account using the passphrase `cheese` to encrypt and store the new account credentials. cheese is not the seed phrase and cannot be used to restore this account from scratch. Calling this function repeatedly with the same passphrase will create multiple unique accounts. Also keep in mind there are no options to export private keys stored in the EVM database. Users are encouraged to use wallet software instead for safer account creation and backup. This method is more suitable for quick account creation for a testnet."
+					},
+					"response": []
+				},
+				{
+					"name": "personal_importRawKey",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"personal_importRawKey\",\n    \"params\": [\n        \"627119bb8286874a15d562d32829613311a678da26ca7a6a785ec4ad85937d07\",\n        \"{{cchainPassphrase}}\"\n    ],\n    \"id\": 1\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/rpc",
+							"protocol": "{{http}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"bc",
+								"C",
+								"rpc"
+							]
+						},
+						"description": "Creating a new account (using plaintext private key).\n\nIf the private key is known upfront, it can be provided as plaintext to load into the EVM account database. For more secure account management, consider using wallet software instead. The example below loads the private key `0x627119bb8286874a15d562d32829613311a678da26ca7a6a785ec4ad85937d06` with the passphrase `this is my passphrase`. Note that `0x` prefix cannot be included in the private key argument, otherwise the EVM will throw an error. The example response returns the associated public key."
+					},
+					"response": []
+				},
+				{
+					"name": "personal_listAccounts",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"personal_listAccounts\",\n    \"params\": [],\n    \"id\": 1\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/rpc",
+							"protocol": "{{http}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"bc",
+								"C",
+								"rpc"
+							]
+						},
+						"description": "Listing accounts loaded in EVM node. [More info](https://docs.avax.network/v1.0/en/api/evm/#listing-accounts-loaded-in-evm-node)"
+					},
+					"response": []
+				},
+				{
+					"name": "personal_unlockAccount",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"personal_unlockAccount\",\n    \"params\": [\n        \"{{cchainAddress}}\",\n        \"{{cchainPassphrase}}\",\n        600\n    ],\n    \"id\": 1\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/rpc",
+							"protocol": "{{http}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"bc",
+								"C",
+								"rpc"
+							]
+						},
+						"description": "Unlocking an account.\n\nPersonal accounts loaded directly in the EVM can only sign transactions while in an unlocked state. The example below unlocks the listed account address for 60 seconds. Note the associated passphrase `cheese` must be provided for authorization. [More info](https://docs.avax.network/v1.0/en/api/evm/#unlocking-an-account)"
+					},
+					"response": []
+				},
+				{
 					"name": "txpool_status",
 					"request": {
 						"method": "POST",
@@ -1568,6 +1650,70 @@
 							]
 						},
 						"description": "Getting count of pending transactions.\n\n“Pending” transactions will be non-zero during periods of heavy network use. “Queued” transactions indicate transactions have been submitted with nonce values ahead of the next expected value for an address, which places them on hold until a transaction with the next expected nonce value is submitted. [More info](https://docs.avax.network/v1.0/en/api/evm/#getting-count-of-pending-transactions)"
+					},
+					"response": []
+				},
+				{
+					"name": "web3_clientVersion",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"web3_clientVersion\",\n    \"params\": [],\n    \"id\": 1\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/rpc",
+							"protocol": "{{http}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"bc",
+								"C",
+								"rpc"
+							]
+						},
+						"description": "Getting the current client version. [More info](https://docs.avax.network/v1.0/en/api/evm/#getting-the-current-client-version)"
+					},
+					"response": []
+				},
+				{
+					"name": "web3_sha3",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"web3_sha3\",\n    \"params\": [\n        \"0x736e6f7773746f726d\"\n    ],\n    \"id\": 1\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/rpc",
+							"protocol": "{{http}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"bc",
+								"C",
+								"rpc"
+							]
+						},
+						"description": "Calculate a cryptographic hash.\n\nThe input parameter contains hexidecimal bytes of arbitrary length. The example here uses the UTF-8 text string “snowstorm” converted to hexidecimal bytes. [More info](https://docs.avax.network/v1.0/en/api/evm/#calculate-a-cryptographic-hash)"
 					},
 					"response": []
 				}
@@ -2136,7 +2282,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/P",
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
 							"protocol": "{{http}}",
 							"host": [
 								"{{host}}"
@@ -2144,6 +2290,7 @@
 							"port": "{{port}}",
 							"path": [
 								"ext",
+								"bc",
 								"P"
 							]
 						},
@@ -2166,7 +2313,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/P",
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
 							"protocol": "{{http}}",
 							"host": [
 								"{{host}}"
@@ -2174,6 +2321,7 @@
 							"port": "{{port}}",
 							"path": [
 								"ext",
+								"bc",
 								"P"
 							]
 						},
@@ -2196,7 +2344,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/P",
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
 							"protocol": "{{http}}",
 							"host": [
 								"{{host}}"
@@ -2204,6 +2352,7 @@
 							"port": "{{port}}",
 							"path": [
 								"ext",
+								"bc",
 								"P"
 							]
 						},
@@ -2226,7 +2375,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/P",
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
 							"protocol": "{{http}}",
 							"host": [
 								"{{host}}"
@@ -2234,6 +2383,7 @@
 							"port": "{{port}}",
 							"path": [
 								"ext",
+								"bc",
 								"P"
 							]
 						},
@@ -2256,7 +2406,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/P",
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
 							"protocol": "{{http}}",
 							"host": [
 								"{{host}}"
@@ -2264,6 +2414,7 @@
 							"port": "{{port}}",
 							"path": [
 								"ext",
+								"bc",
 								"P"
 							]
 						},
@@ -2286,7 +2437,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/P",
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
 							"protocol": "{{http}}",
 							"host": [
 								"{{host}}"
@@ -2294,6 +2445,7 @@
 							"port": "{{port}}",
 							"path": [
 								"ext",
+								"bc",
 								"P"
 							]
 						},
@@ -2316,7 +2468,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/P",
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
 							"protocol": "{{http}}",
 							"host": [
 								"{{host}}"
@@ -2324,6 +2476,7 @@
 							"port": "{{port}}",
 							"path": [
 								"ext",
+								"bc",
 								"P"
 							]
 						},
@@ -2346,7 +2499,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/P",
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
 							"protocol": "{{http}}",
 							"host": [
 								"{{host}}"
@@ -2354,6 +2507,7 @@
 							"port": "{{port}}",
 							"path": [
 								"ext",
+								"bc",
 								"P"
 							]
 						},
@@ -2376,7 +2530,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/P",
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
 							"protocol": "{{http}}",
 							"host": [
 								"{{host}}"
@@ -2384,6 +2538,7 @@
 							"port": "{{port}}",
 							"path": [
 								"ext",
+								"bc",
 								"P"
 							]
 						},
@@ -2406,7 +2561,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/P",
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
 							"protocol": "{{http}}",
 							"host": [
 								"{{host}}"
@@ -2414,6 +2569,7 @@
 							"port": "{{port}}",
 							"path": [
 								"ext",
+								"bc",
 								"P"
 							]
 						},
@@ -2428,7 +2584,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getHeight\",\n    \"params\": {}\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getStakingAssetID\",\n    \"params\": {}\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -2436,7 +2592,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/P",
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
 							"protocol": "{{http}}",
 							"host": [
 								"{{host}}"
@@ -2444,6 +2600,7 @@
 							"port": "{{port}}",
 							"path": [
 								"ext",
+								"bc",
 								"P"
 							]
 						},
@@ -2466,7 +2623,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/P",
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
 							"protocol": "{{http}}",
 							"host": [
 								"{{host}}"
@@ -2474,6 +2631,7 @@
 							"port": "{{port}}",
 							"path": [
 								"ext",
+								"bc",
 								"P"
 							]
 						},
@@ -2496,7 +2654,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/P",
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
 							"protocol": "{{http}}",
 							"host": [
 								"{{host}}"
@@ -2504,6 +2662,7 @@
 							"port": "{{port}}",
 							"path": [
 								"ext",
+								"bc",
 								"P"
 							]
 						},
@@ -2518,7 +2677,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.getTxStatus\",\n    \"params\": {\n        \"txID\": \"g2qkgkbfwkSrjKvCHN79XC3FkvC4pcC1abubLce42cyh2bSh9\"\n    },\n    \"id\": 1\n}",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.getTxStatus\",\n    \"params\": {\n        \"txID\": \"23CLURk1Czf1aLui1VdcuWSiDeFskfp3Sn8TQG7t6NKfeQRYDj\"\n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -2526,7 +2685,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/P",
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
 							"protocol": "{{http}}",
 							"host": [
 								"{{host}}"
@@ -2534,6 +2693,7 @@
 							"port": "{{port}}",
 							"path": [
 								"ext",
+								"bc",
 								"P"
 							]
 						},
@@ -2556,7 +2716,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/P",
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
 							"protocol": "{{http}}",
 							"host": [
 								"{{host}}"
@@ -2564,6 +2724,7 @@
 							"port": "{{port}}",
 							"path": [
 								"ext",
+								"bc",
 								"P"
 							]
 						},
@@ -2586,7 +2747,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/P",
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
 							"protocol": "{{http}}",
 							"host": [
 								"{{host}}"
@@ -2594,6 +2755,7 @@
 							"port": "{{port}}",
 							"path": [
 								"ext",
+								"bc",
 								"P"
 							]
 						},
@@ -2647,7 +2809,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/P",
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
 							"protocol": "{{http}}",
 							"host": [
 								"{{host}}"
@@ -2655,6 +2817,7 @@
 							"port": "{{port}}",
 							"path": [
 								"ext",
+								"bc",
 								"P"
 							]
 						},
@@ -2677,7 +2840,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/P",
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
 							"protocol": "{{http}}",
 							"host": [
 								"{{host}}"
@@ -2685,6 +2848,7 @@
 							"port": "{{port}}",
 							"path": [
 								"ext",
+								"bc",
 								"P"
 							]
 						},
@@ -2707,7 +2871,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/P",
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
 							"protocol": "{{http}}",
 							"host": [
 								"{{host}}"
@@ -2715,6 +2879,7 @@
 							"port": "{{port}}",
 							"path": [
 								"ext",
+								"bc",
 								"P"
 							]
 						},
@@ -2737,7 +2902,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/P",
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
 							"protocol": "{{http}}",
 							"host": [
 								"{{host}}"
@@ -2745,6 +2910,7 @@
 							"port": "{{port}}",
 							"path": [
 								"ext",
+								"bc",
 								"P"
 							]
 						},
@@ -2767,7 +2933,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/P",
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
 							"protocol": "{{http}}",
 							"host": [
 								"{{host}}"
@@ -2775,6 +2941,7 @@
 							"port": "{{port}}",
 							"path": [
 								"ext",
+								"bc",
 								"P"
 							]
 						},
@@ -2797,7 +2964,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/P",
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
 							"protocol": "{{http}}",
 							"host": [
 								"{{host}}"
@@ -2805,6 +2972,7 @@
 							"port": "{{port}}",
 							"path": [
 								"ext",
+								"bc",
 								"P"
 							]
 						},
@@ -2827,7 +2995,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/P",
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
 							"protocol": "{{http}}",
 							"host": [
 								"{{host}}"
@@ -2835,6 +3003,7 @@
 							"port": "{{port}}",
 							"path": [
 								"ext",
+								"bc",
 								"P"
 							]
 						},
@@ -2857,7 +3026,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/P",
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
 							"protocol": "{{http}}",
 							"host": [
 								"{{host}}"
@@ -2865,6 +3034,7 @@
 							"port": "{{port}}",
 							"path": [
 								"ext",
+								"bc",
 								"P"
 							]
 						},
@@ -2887,7 +3057,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/P",
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
 							"protocol": "{{http}}",
 							"host": [
 								"{{host}}"
@@ -2895,6 +3065,7 @@
 							"port": "{{port}}",
 							"path": [
 								"ext",
+								"bc",
 								"P"
 							]
 						},
@@ -2917,7 +3088,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/P",
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
 							"protocol": "{{http}}",
 							"host": [
 								"{{host}}"
@@ -2925,6 +3096,7 @@
 							"port": "{{port}}",
 							"path": [
 								"ext",
+								"bc",
 								"P"
 							]
 						},
@@ -2947,7 +3119,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/P",
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
 							"protocol": "{{http}}",
 							"host": [
 								"{{host}}"
@@ -2955,6 +3127,7 @@
 							"port": "{{port}}",
 							"path": [
 								"ext",
+								"bc",
 								"P"
 							]
 						},

--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -23,12 +23,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/admin",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/admin",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"admin"
@@ -53,12 +51,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/admin",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/admin",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"admin"
@@ -83,12 +79,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/admin",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/admin",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"admin"
@@ -113,12 +107,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/admin",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/admin",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"admin"
@@ -143,12 +135,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/admin",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/admin",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"admin"
@@ -173,12 +163,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/admin",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/admin",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"admin"
@@ -203,12 +191,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/admin",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/admin",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"admin"
@@ -233,12 +219,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/admin",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/admin",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"admin"
@@ -263,12 +247,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/admin",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/admin",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"admin"
@@ -293,12 +275,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/admin",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/admin",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"admin"
@@ -329,12 +309,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/auth",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/auth",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"auth"
@@ -359,12 +337,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/auth",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/auth",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"auth"
@@ -389,12 +365,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/auth",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/auth",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"auth"
@@ -417,7 +391,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"id\"     : 1,\n    \"method\" : \"avm.buildGenesis\",\n    \"params\" : {\n        \"genesisData\": {\n            \"asset1\": {\n                \"name\": \"asset1\",\n                \"symbol\":\"MFCA\",\n                \"memo\": \"2Zc54v4ek37TEwu4LiV3j41PUMRd6acDDU3ZCVSxE7X\",\n                \"denomination\": 1, \n                \"initialState\": {\n                    \"fixedCap\" : [\n                        {\n                            \"amount\":100000,\n                            \"address\": \"local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u\"\n                        }\n                    ]\n                }\n            },\n            \"asset2\": {\n                \"name\": \"asset2\",\n                \"symbol\":\"MVCA\",\n                \"memo\": \"2Zc54v4ek37TEwu4LiV3j41PUMRd6acDDU3ZCVSxE7X\",\n                \"denomination\": 2, \n                \"initialState\": {\n                    \"variableCap\" : [\n                        {\n                            \"amount\":100000,\n                            \"address\": \"local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u\"\n                        }\n                    ]\n                }\n            }\n        },\n        \"networkId\": 12345,\n        \"encoding\":\"cb58\"\n    }\n}",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"id\"     : 1,\n    \"method\" : \"avm.buildGenesis\",\n    \"params\" : {\n        \"genesisData\": {\n            \"asset1\": {\n                \"name\": \"asset1\",\n                \"symbol\":\"MFCA\",\n                \"memo\": \"2Zc54v4ek37TEwu4LiV3j41PUMRd6acDDU3ZCVSxE7X\",\n                \"denomination\": 1, \n                \"initialState\": {\n                    \"fixedCap\" : [\n                        {\n                            \"amount\":100000,\n                            \"address\": \"custom18jma8ppw3nhx5r4ap8clazz0dps7rv5u9xde7p\"\n                        }\n                    ]\n                }\n            },\n            \"asset2\": {\n                \"name\": \"asset2\",\n                \"symbol\":\"MVCA\",\n                \"memo\": \"2Zc54v4ek37TEwu4LiV3j41PUMRd6acDDU3ZCVSxE7X\",\n                \"denomination\": 2, \n                \"initialState\": {\n                    \"variableCap\" : [\n                        {\n                            \"amount\":100000,\n                            \"address\": \"custom18jma8ppw3nhx5r4ap8clazz0dps7rv5u9xde7p\"\n                        }\n                    ]\n                }\n            }\n        },\n        \"networkId\": 1337,\n        \"encoding\":\"cb58\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -425,12 +399,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/vm/avm",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/vm/avm",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"vm",
@@ -456,12 +428,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/X",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/X",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -487,12 +457,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/X",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/X",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -518,12 +486,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/X",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/X",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -549,12 +515,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/X",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/X",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -580,12 +544,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/X",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/X",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -611,12 +573,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/X",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/X",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -624,6 +584,35 @@
 							]
 						},
 						"description": "Export a non-AVAX asset from the X-Chain to the C-Chain. After calling this method, you must call the C-Chain’s `import` method to complete the transfer. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmexport)"
+					},
+					"response": []
+				},
+				{
+					"name": "exportAVAX",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.exportAVAX\",\n    \"params\" :{\n        \"from\": [\"{{xchainAddress}}\"],\n        \"to\":\"{{cchainbech32address}}\",\n        \"amount\": 4000001000000,\n        \"destinationChain\": \"C\",\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseURL}}/ext/bc/X",
+							"host": [
+								"{{baseURL}}"
+							],
+							"path": [
+								"ext",
+								"bc",
+								"X"
+							]
+						},
+						"description": "Export AVAX from the X-Chain to both the P-Chain as well as the C-Chain. After calling this method, you must call either the P-Chain’s `importAVAX` method or the C-Chain's `importAVAX` method to complete the transfer. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-exportavax)"
 					},
 					"response": []
 				},
@@ -642,12 +631,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/X",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/X",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -673,12 +660,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/X",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/X",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -704,12 +689,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/X",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/X",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -735,12 +718,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/X",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/X",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -797,12 +778,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/X",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/X",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -828,12 +807,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/X",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/X",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -859,12 +836,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/X",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/X",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -890,12 +865,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/X",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/X",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -921,12 +894,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/X",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/X",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -934,6 +905,35 @@
 							]
 						},
 						"description": "Finalize a transfer of AVAX from either the P-Chain to the X-Chain or the C-Chain to the X-Chain.\n\nBefore this method is called, you must call either the P-Chain’s `exportAVAX` method or the C-Chain’s `exportAVAX` method to initiate the transfer. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmimportavax)"
+					},
+					"response": []
+				},
+				{
+					"name": "importAVAX",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.importAVAX\",\n    \"params\" :{\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"sourceChain\": \"C\",\n        \"to\":\"{{xchainAddress}}\"\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseURL}}/ext/bc/X",
+							"host": [
+								"{{baseURL}}"
+							],
+							"path": [
+								"ext",
+								"bc",
+								"X"
+							]
+						},
+						"description": "Finalize a transfer of AVAX from either the P-Chain to the X-Chain or the C-Chain to the X-Chain.\n\nBefore this method is called, you must call either the P-Chain’s `exportAVAX` method or the C-Chain’s `exportAVAX` method to initiate the transfer. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-importavax)"
 					},
 					"response": []
 				},
@@ -952,12 +952,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/X",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/X",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -983,12 +981,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/X",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/X",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -1014,12 +1010,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/X",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/X",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -1045,12 +1039,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/X",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/X",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -1076,12 +1068,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/X",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/X",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -1107,12 +1097,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/X",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/X",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -1138,12 +1126,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/X",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/X",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -1169,12 +1155,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/X",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/X",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -1200,12 +1184,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/X",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/X",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -1231,12 +1213,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/X",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/X",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -1268,12 +1248,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/rpc",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/C/rpc",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -1300,12 +1278,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/rpc",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/C/rpc",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -1332,12 +1308,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/rpc",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/C/rpc",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -1364,12 +1338,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/rpc",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/C/rpc",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -1396,12 +1368,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/rpc",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/C/rpc",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -1428,12 +1398,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/rpc",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/C/rpc",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -1460,12 +1428,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/rpc",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/C/rpc",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -1492,12 +1458,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/rpc",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/C/rpc",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -1524,12 +1488,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/rpc",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/C/rpc",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -1556,12 +1518,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/rpc",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/C/rpc",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -1588,12 +1548,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/rpc",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/C/rpc",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -1620,12 +1578,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/rpc",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/C/rpc",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -1652,12 +1608,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/rpc",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/C/rpc",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -1684,12 +1638,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/rpc",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/C/rpc",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -1716,12 +1668,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/avax",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/C/avax",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -1748,12 +1698,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/avax",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/C/avax",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -1780,12 +1728,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/avax",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/C/avax",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -1812,12 +1758,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/avax",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/C/avax",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -1844,12 +1788,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/avax",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/C/avax",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -1876,12 +1818,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/avax",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/C/avax",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -1908,12 +1848,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/avax",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/C/avax",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -1940,12 +1878,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/avax",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/C/avax",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -1972,12 +1908,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/avax",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/C/avax",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -2004,12 +1938,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/avax",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/C/avax",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -2036,12 +1968,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/rpc",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/C/rpc",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -2068,12 +1998,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/rpc",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/C/rpc",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -2100,12 +2028,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/rpc",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/C/rpc",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -2132,12 +2058,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/rpc",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/C/rpc",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -2164,12 +2088,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/rpc",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/C/rpc",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -2196,12 +2118,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/rpc",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/C/rpc",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -2228,12 +2148,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/rpc",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/C/rpc",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -2260,12 +2178,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/rpc",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/C/rpc",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -2298,12 +2214,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/health",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/health",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"health"
@@ -2337,12 +2251,10 @@
 									}
 								},
 								"url": {
-									"raw": "{{protocol}}://{{host}}:{{port}}/ext/index/X/tx",
-									"protocol": "{{protocol}}",
+									"raw": "{{baseURL}}/ext/index/X/tx",
 									"host": [
-										"{{host}}"
+										"{{baseURL}}"
 									],
-									"port": "{{port}}",
 									"path": [
 										"ext",
 										"index",
@@ -2369,12 +2281,10 @@
 									}
 								},
 								"url": {
-									"raw": "{{protocol}}://{{host}}:{{port}}/ext/index/X/tx",
-									"protocol": "{{protocol}}",
+									"raw": "{{baseURL}}/ext/index/X/tx",
 									"host": [
-										"{{host}}"
+										"{{baseURL}}"
 									],
-									"port": "{{port}}",
 									"path": [
 										"ext",
 										"index",
@@ -2401,12 +2311,10 @@
 									}
 								},
 								"url": {
-									"raw": "{{protocol}}://{{host}}:{{port}}/ext/index/X/tx",
-									"protocol": "{{protocol}}",
+									"raw": "{{baseURL}}/ext/index/X/tx",
 									"host": [
-										"{{host}}"
+										"{{baseURL}}"
 									],
-									"port": "{{port}}",
 									"path": [
 										"ext",
 										"index",
@@ -2433,12 +2341,10 @@
 									}
 								},
 								"url": {
-									"raw": "{{protocol}}://{{host}}:{{port}}/ext/index/X/tx",
-									"protocol": "{{protocol}}",
+									"raw": "{{baseURL}}/ext/index/X/tx",
 									"host": [
-										"{{host}}"
+										"{{baseURL}}"
 									],
-									"port": "{{port}}",
 									"path": [
 										"ext",
 										"index",
@@ -2465,12 +2371,10 @@
 									}
 								},
 								"url": {
-									"raw": "{{protocol}}://{{host}}:{{port}}/ext/index/X/tx",
-									"protocol": "{{protocol}}",
+									"raw": "{{baseURL}}/ext/index/X/tx",
 									"host": [
-										"{{host}}"
+										"{{baseURL}}"
 									],
-									"port": "{{port}}",
 									"path": [
 										"ext",
 										"index",
@@ -2497,12 +2401,10 @@
 									}
 								},
 								"url": {
-									"raw": "{{protocol}}://{{host}}:{{port}}/ext/index/X/tx",
-									"protocol": "{{protocol}}",
+									"raw": "{{baseURL}}/ext/index/X/tx",
 									"host": [
-										"{{host}}"
+										"{{baseURL}}"
 									],
-									"port": "{{port}}",
 									"path": [
 										"ext",
 										"index",
@@ -2534,12 +2436,10 @@
 									}
 								},
 								"url": {
-									"raw": "{{protocol}}://{{host}}:{{port}}/ext/index/X/vtx",
-									"protocol": "{{protocol}}",
+									"raw": "{{baseURL}}/ext/index/X/vtx",
 									"host": [
-										"{{host}}"
+										"{{baseURL}}"
 									],
-									"port": "{{port}}",
 									"path": [
 										"ext",
 										"index",
@@ -2566,12 +2466,10 @@
 									}
 								},
 								"url": {
-									"raw": "{{protocol}}://{{host}}:{{port}}/ext/index/X/vtx",
-									"protocol": "{{protocol}}",
+									"raw": "{{baseURL}}/ext/index/X/vtx",
 									"host": [
-										"{{host}}"
+										"{{baseURL}}"
 									],
-									"port": "{{port}}",
 									"path": [
 										"ext",
 										"index",
@@ -2598,12 +2496,10 @@
 									}
 								},
 								"url": {
-									"raw": "{{protocol}}://{{host}}:{{port}}/ext/index/X/vtx",
-									"protocol": "{{protocol}}",
+									"raw": "{{baseURL}}/ext/index/X/vtx",
 									"host": [
-										"{{host}}"
+										"{{baseURL}}"
 									],
-									"port": "{{port}}",
 									"path": [
 										"ext",
 										"index",
@@ -2630,12 +2526,10 @@
 									}
 								},
 								"url": {
-									"raw": "{{protocol}}://{{host}}:{{port}}/ext/index/X/vtx",
-									"protocol": "{{protocol}}",
+									"raw": "{{baseURL}}/ext/index/X/vtx",
 									"host": [
-										"{{host}}"
+										"{{baseURL}}"
 									],
-									"port": "{{port}}",
 									"path": [
 										"ext",
 										"index",
@@ -2662,12 +2556,10 @@
 									}
 								},
 								"url": {
-									"raw": "{{protocol}}://{{host}}:{{port}}/ext/index/X/vtx",
-									"protocol": "{{protocol}}",
+									"raw": "{{baseURL}}/ext/index/X/vtx",
 									"host": [
-										"{{host}}"
+										"{{baseURL}}"
 									],
-									"port": "{{port}}",
 									"path": [
 										"ext",
 										"index",
@@ -2694,12 +2586,10 @@
 									}
 								},
 								"url": {
-									"raw": "{{protocol}}://{{host}}:{{port}}/ext/index/X/vtx",
-									"protocol": "{{protocol}}",
+									"raw": "{{baseURL}}/ext/index/X/vtx",
 									"host": [
-										"{{host}}"
+										"{{baseURL}}"
 									],
-									"port": "{{port}}",
 									"path": [
 										"ext",
 										"index",
@@ -2731,12 +2621,10 @@
 									}
 								},
 								"url": {
-									"raw": "{{protocol}}://{{host}}:{{port}}/ext/index/P/block",
-									"protocol": "{{protocol}}",
+									"raw": "{{baseURL}}/ext/index/P/block",
 									"host": [
-										"{{host}}"
+										"{{baseURL}}"
 									],
-									"port": "{{port}}",
 									"path": [
 										"ext",
 										"index",
@@ -2763,12 +2651,10 @@
 									}
 								},
 								"url": {
-									"raw": "{{protocol}}://{{host}}:{{port}}/ext/index/P/block",
-									"protocol": "{{protocol}}",
+									"raw": "{{baseURL}}/ext/index/P/block",
 									"host": [
-										"{{host}}"
+										"{{baseURL}}"
 									],
-									"port": "{{port}}",
 									"path": [
 										"ext",
 										"index",
@@ -2795,12 +2681,10 @@
 									}
 								},
 								"url": {
-									"raw": "{{protocol}}://{{host}}:{{port}}/ext/index/P/block",
-									"protocol": "{{protocol}}",
+									"raw": "{{baseURL}}/ext/index/P/block",
 									"host": [
-										"{{host}}"
+										"{{baseURL}}"
 									],
-									"port": "{{port}}",
 									"path": [
 										"ext",
 										"index",
@@ -2827,12 +2711,10 @@
 									}
 								},
 								"url": {
-									"raw": "{{protocol}}://{{host}}:{{port}}/ext/index/P/block",
-									"protocol": "{{protocol}}",
+									"raw": "{{baseURL}}/ext/index/P/block",
 									"host": [
-										"{{host}}"
+										"{{baseURL}}"
 									],
-									"port": "{{port}}",
 									"path": [
 										"ext",
 										"index",
@@ -2859,12 +2741,10 @@
 									}
 								},
 								"url": {
-									"raw": "{{protocol}}://{{host}}:{{port}}/ext/index/P/block",
-									"protocol": "{{protocol}}",
+									"raw": "{{baseURL}}/ext/index/P/block",
 									"host": [
-										"{{host}}"
+										"{{baseURL}}"
 									],
-									"port": "{{port}}",
 									"path": [
 										"ext",
 										"index",
@@ -2891,12 +2771,10 @@
 									}
 								},
 								"url": {
-									"raw": "{{protocol}}://{{host}}:{{port}}/ext/index/P/block",
-									"protocol": "{{protocol}}",
+									"raw": "{{baseURL}}/ext/index/P/block",
 									"host": [
-										"{{host}}"
+										"{{baseURL}}"
 									],
-									"port": "{{port}}",
 									"path": [
 										"ext",
 										"index",
@@ -2928,12 +2806,10 @@
 									}
 								},
 								"url": {
-									"raw": "{{protocol}}://{{host}}:{{port}}/ext/index/C/block",
-									"protocol": "{{protocol}}",
+									"raw": "{{baseURL}}/ext/index/C/block",
 									"host": [
-										"{{host}}"
+										"{{baseURL}}"
 									],
-									"port": "{{port}}",
 									"path": [
 										"ext",
 										"index",
@@ -2960,12 +2836,10 @@
 									}
 								},
 								"url": {
-									"raw": "{{protocol}}://{{host}}:{{port}}/ext/index/C/block",
-									"protocol": "{{protocol}}",
+									"raw": "{{baseURL}}/ext/index/C/block",
 									"host": [
-										"{{host}}"
+										"{{baseURL}}"
 									],
-									"port": "{{port}}",
 									"path": [
 										"ext",
 										"index",
@@ -2992,12 +2866,10 @@
 									}
 								},
 								"url": {
-									"raw": "{{protocol}}://{{host}}:{{port}}/ext/index/C/block",
-									"protocol": "{{protocol}}",
+									"raw": "{{baseURL}}/ext/index/C/block",
 									"host": [
-										"{{host}}"
+										"{{baseURL}}"
 									],
-									"port": "{{port}}",
 									"path": [
 										"ext",
 										"index",
@@ -3024,12 +2896,10 @@
 									}
 								},
 								"url": {
-									"raw": "{{protocol}}://{{host}}:{{port}}/ext/index/C/block",
-									"protocol": "{{protocol}}",
+									"raw": "{{baseURL}}/ext/index/C/block",
 									"host": [
-										"{{host}}"
+										"{{baseURL}}"
 									],
-									"port": "{{port}}",
 									"path": [
 										"ext",
 										"index",
@@ -3056,12 +2926,10 @@
 									}
 								},
 								"url": {
-									"raw": "{{protocol}}://{{host}}:{{port}}/ext/index/C/block",
-									"protocol": "{{protocol}}",
+									"raw": "{{baseURL}}/ext/index/C/block",
 									"host": [
-										"{{host}}"
+										"{{baseURL}}"
 									],
-									"port": "{{port}}",
 									"path": [
 										"ext",
 										"index",
@@ -3088,12 +2956,10 @@
 									}
 								},
 								"url": {
-									"raw": "{{protocol}}://{{host}}:{{port}}/ext/index/C/block",
-									"protocol": "{{protocol}}",
+									"raw": "{{baseURL}}/ext/index/C/block",
 									"host": [
-										"{{host}}"
+										"{{baseURL}}"
 									],
-									"port": "{{port}}",
 									"path": [
 										"ext",
 										"index",
@@ -3128,12 +2994,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/info",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/info",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"info"
@@ -3158,12 +3022,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/info",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/info",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"info"
@@ -3188,12 +3050,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/info",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/info",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"info"
@@ -3218,12 +3078,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/info",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/info",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"info"
@@ -3248,12 +3106,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/info",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/info",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"info"
@@ -3278,12 +3134,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/info",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/info",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"info"
@@ -3308,12 +3162,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/info",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/info",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"info"
@@ -3338,12 +3190,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/info",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/info",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"info"
@@ -3368,12 +3218,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/info",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/info",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"info"
@@ -3398,12 +3246,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/info",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/info",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"info"
@@ -3428,12 +3274,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/info",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/info",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"info"
@@ -3464,12 +3308,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/ipcs",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/ipcs",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"ipcs"
@@ -3494,12 +3336,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/ipcs",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/ipcs",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"ipcs"
@@ -3530,12 +3370,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/keystore",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/keystore",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"keystore"
@@ -3560,12 +3398,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/keystore",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/keystore",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"keystore"
@@ -3590,12 +3426,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/keystore",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/keystore",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"keystore"
@@ -3620,12 +3454,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/keystore",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/keystore",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"keystore"
@@ -3650,12 +3482,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/keystore",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/keystore",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"keystore"
@@ -3681,12 +3511,10 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/metrics",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/metrics",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"metrics"
@@ -3717,12 +3545,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/P",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -3748,12 +3574,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/P",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -3779,12 +3603,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/P",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -3810,12 +3632,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/P",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -3841,12 +3661,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/P",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -3872,12 +3690,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/P",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -3895,7 +3711,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getBalance\",\n    \"params\" :{\n      \"address\":\"{{pchainAddress}}\"    \n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getBalance\",\n    \"params\" :{\n      \"address\":\"P-custom1u6eth2fg33ye63mnyu5jswtj326jaypvhyar45\"    \n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -3903,12 +3719,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/P",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -3934,12 +3748,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/P",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -3965,12 +3777,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/P",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -3996,12 +3806,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/P",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -4027,12 +3835,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/P",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -4058,12 +3864,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/P",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -4089,12 +3893,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/P",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -4120,12 +3922,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/P",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -4151,12 +3951,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/P",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -4182,12 +3980,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/P",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -4213,12 +4009,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/P",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -4244,12 +4038,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/P",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -4275,12 +4067,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/P",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -4306,12 +4096,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/P",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -4337,12 +4125,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/P",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -4368,12 +4154,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/P",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -4399,12 +4183,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/P",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -4430,12 +4212,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/P",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -4461,12 +4241,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/P",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -4492,12 +4270,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/P",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -4523,12 +4299,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/P",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -4554,12 +4328,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/P",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -4585,12 +4357,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/P",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -4616,12 +4386,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/P",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -4647,12 +4415,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/P",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -4678,12 +4444,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/P",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -4709,12 +4473,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/P",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -4740,12 +4502,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/P",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -4771,12 +4531,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/P",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",
@@ -4802,12 +4560,10 @@
 							}
 						},
 						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{protocol}}",
+							"raw": "{{baseURL}}/ext/bc/P",
 							"host": [
-								"{{host}}"
+								"{{baseURL}}"
 							],
-							"port": "{{port}}",
 							"path": [
 								"ext",
 								"bc",

--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -2225,13 +2225,13 @@
 			"name": "Health",
 			"item": [
 				{
-					"name": "getLiveness",
+					"name": "health",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"health.getLiveness\"\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"health.health\"\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -2250,7 +2250,7 @@
 								"health"
 							]
 						},
-						"description": "Get health check on this node. [More info](https://docs.avax.network/build/apis/health-api#health-getliveness)"
+						"description": "Get health check on this node. [More info](https://docs.avax.network/build/apis/health-api#health-health)"
 					},
 					"response": []
 				}

--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -360,7 +360,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.createFixedCapAsset\",\n    \"params\" :{\n        \"name\": \"Test Token\",\n        \"symbol\":\"TEST\",\n        \"initialHolders\": [\n            {\n                \"address\":\"{{xchainAddress}}\",\n                \"amount\":400\n            }\n        ],\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.createFixedCapAsset\",\n    \"params\" :{\n        \"name\": \"Test Token\",\n        \"symbol\":\"TEST\",\n        \"initialHolders\": [\n            {\n                \"address\":\"{{xchainAddress}}\",\n                \"amount\":400\n            }\n        ],\n        \"from\": [\"{{xchainAddress}}\"],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -390,7 +390,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.createNFTAsset\",\n    \"params\" :{\n        \"name\":\"Coincert\",\n        \"symbol\":\"TIXX\",\n        \"minterSets\":[\n            {\n                \"minters\":[\n                    \"{{xchainAddress}}\"\n                ],\n                \"threshold\": 1\n            }\n        ],\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.createNFTAsset\",\n    \"params\" :{\n        \"name\":\"Coincert\",\n        \"symbol\":\"TIXX\",\n        \"minterSets\":[\n            {\n                \"minters\":[\n                    \"{{xchainAddress}}\"\n                ],\n                \"threshold\": 1\n            }\n        ],\n        \"from\": [\"{{xchainAddress}}\"],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -420,7 +420,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.createVariableCapAsset\",\n    \"params\" :{\n        \"name\":\"myVariableCapAsset\",\n        \"symbol\":\"MFCA\",\n        \"minterSets\":[\n            {\n                \"minters\":[\n                    \"{{xchainAddress}}\"\n                ],\n                \"threshold\": 1\n            },\n            {\n                \"minters\": [\n                    \"X-local1xywj3thpwhregec3en5d80la5utdepemnfglul\",\n                    \"X-local1zuentmjqe22gra0e6n7fjnvz8xg3klad6s4l3p\",\n                    \"X-local1skxqa40msdytj82rqcdtmrd2dqamvsncly0xra\"\n                ],\n                \"threshold\": 2\n            }\n        ],\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.createVariableCapAsset\",\n    \"params\" :{\n        \"name\":\"myVariableCapAsset\",\n        \"symbol\":\"MFCA\",\n        \"minterSets\":[\n            {\n                \"minters\":[\n                    \"{{xchainAddress}}\"\n                ],\n                \"threshold\": 1\n            }\n        ],\n        \"from\": [\"{{xchainAddress}}\"],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -450,7 +450,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.exportAVAX\",\n    \"params\" :{\n        \"to\":\"{{pchainAddress}}\",\n        \"amount\": 4000001000000,\n        \"destinationChain\": \"P\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.exportAVAX\",\n    \"params\" :{\n        \"from\": [\"{{xchainAddress}}\"],\n        \"to\":\"{{cchainbech32address}}\",\n        \"amount\": 4000001000000,\n        \"destinationChain\": \"C\",\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -843,7 +843,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.mint\",\n    \"params\" :{\n        \"amount\":10000000,\n        \"assetID\":\"2qnR9pLQTDZ9boSbcrcjS4n1DJJkzbkNsJzgwYvmRy8uv47fZT\",\n        \"to\":\"{{xchainAddress}}\",\n        \"minters\":[\n            \"{{xchainAddress}}\"\n        ],\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.mint\",\n    \"params\" :{\n        \"amount\": 10000000,\n        \"assetID\": \"2qnR9pLQTDZ9boSbcrcjS4n1DJJkzbkNsJzgwYvmRy8uv47fZT\",\n        \"from\": [\"{{xchainAddress}}\"],\n        \"to\": \"{{xchainAddress}}\",\n        \"minters\": [\n            \"{{xchainAddress}}\"\n        ],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\" \n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -873,7 +873,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.mintNFT\",\n    \"params\" :{\n        \"amount\":1,\n        \"assetID\":\"7ifkSF7D2heHgF7owoWQgzDV4fDzneqWJ9B4qa7peMPE8foBf\",\n        \"payload\":\"2EWh72jYQvEJF9NLk\",\n        \"to\":\"{{xchainAddress}}\",\n        \"minters\":[\n            \"X-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u\"\n        ],\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.mintNFT\",\n    \"params\" :{\n        \"amount\":1,\n        \"assetID\":\"7ifkSF7D2heHgF7owoWQgzDV4fDzneqWJ9B4qa7peMPE8foBf\",\n        \"payload\":\"2EWh72jYQvEJF9NLk\",\n        \"from\": [\"{{xchainAddress}}\"],\n        \"to\":\"{{xchainAddress}}\",\n        \"minters\":[\n            \"X-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u\"\n        ],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -903,7 +903,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.send\",\n    \"params\" :{ \n        \"assetID\" :\"{{avaxAssetId}}\",\n        \"amount\"  :10000,\n        \"to\"      :\"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.send\",\n    \"params\" :{ \n        \"assetID\" : \"{{avaxAssetId}}\",\n        \"amount\"  : 10000,\n        \"from\"    : [\"{{xchainAddress}}\"],\n        \"to\"      : \"{{xchainAddress}}\",\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\" \n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -933,7 +933,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.sendNFT\",\n    \"params\" :{ \n        \"assetID\" :\"2Y1VBSy8WX5T7f7ifMPpjm8jbFWYvVv1iSQefhAcpwokhk2GXX\",\n        \"to\"      :\"{{xchainAddress}}\",\n        \"groupID\" : 0,\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.sendNFT\",\n    \"params\" :{ \n        \"assetID\" :\"2Y1VBSy8WX5T7f7ifMPpjm8jbFWYvVv1iSQefhAcpwokhk2GXX\",\n        \"from\"    : [\"{{xchainAddress}}\"],\n        \"to\"      :\"{{xchainAddress}}\",\n        \"groupID\" : 0,\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1188,13 +1188,13 @@
 					"response": []
 				},
 				{
-					"name": "importAVAX",
+					"name": "export",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"avax.importAVAX\",\n    \"params\": {\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"sourceChain\": \"X\",\n        \"to\":\"0x4b879aff6b3d24352Ac1985c1F45BA4c3493A398\"\n    },\n    \"id\": 1\n}",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"avax.export\",\n    \"params\": {\n        \"to\":\"{{xchainAddress}}\",\n        \"amount\": 5,\n        \"assetID\": \"2WGXKuZoHNjoHxMUhSvT1iFnps3tGGGpfJFDKN3Lyt5QmUhBBL\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1257,6 +1257,68 @@
 						"body": {
 							"mode": "raw",
 							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"avax.exportKey\",\n    \"params\": {\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"address\":\"{{cchainAddress}}\"\n    },\n    \"id\": 1\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/avax",
+							"protocol": "{{http}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"bc",
+								"C",
+								"avax"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "import",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"avax.import\",\n    \"params\": {\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"assetID\": \"2nzgmhZLuVq8jc7NNu2eahkKwoJcbFWXWJCxHBVWAJEZkhquoK\",\n        \"sourceChain\": \"X\",\n        \"to\":\"{{cchainAddress}}\"\n    },\n    \"id\": 1\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/avax",
+							"protocol": "{{http}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"bc",
+								"C",
+								"avax"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "importAVAX",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"avax.importAVAX\",\n    \"params\": {\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"sourceChain\": \"X\",\n        \"to\":\"{{cchainAddress}}\"\n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"

--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -1,8 +1,9 @@
 {
 	"info": {
-		"_postman_id": "72e39b9d-49f8-416f-89db-118fcb994d21",
+		"_postman_id": "1ee7a070-3262-42d5-9cb2-3ec00a0a5d5e",
 		"name": "Avalanche",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "12086068"
 	},
 	"item": [
 		{
@@ -588,35 +589,6 @@
 					"response": []
 				},
 				{
-					"name": "exportAVAX",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.exportAVAX\",\n    \"params\" :{\n        \"from\": [\"{{xchainAddress}}\"],\n        \"to\":\"{{cchainbech32address}}\",\n        \"amount\": 4000001000000,\n        \"destinationChain\": \"C\",\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/X",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"X"
-							]
-						},
-						"description": "Export AVAX from the X-Chain to both the P-Chain as well as the C-Chain. After calling this method, you must call either the P-Chain’s `importAVAX` method or the C-Chain's `importAVAX` method to complete the transfer. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-exportavax)"
-					},
-					"response": []
-				},
-				{
 					"name": "exportKey",
 					"request": {
 						"method": "POST",
@@ -652,7 +624,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.getAllBalances\",\n    \"params\" :{\n        \"address\":\"{{xchainAddress}}\"\n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.getAddressTxs\",\n    \"params\" :{\n        \"address\":\"{{xchainAddress}}\",\n        \"assetID\": \"AVAX\",\n        \"pageSize\": 20,\n        \"cursor\": 0\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -799,7 +771,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.getTx\",\n    \"params\" :{\n        \"txID\":\"2QouvFWUbjuySRxeX5xMbNCuAaKWfbk5FeEa2JmoF85RKLk2dD\",\n        \"encoding\": \"hex\"\n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.getTx\",\n    \"params\" :{\n        \"txID\":\"{{txID}}\",\n        \"encoding\": \"hex\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -828,7 +800,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"id\": 1,\n    \"method\": \"avm.getTxStatus\",\n    \"params\": {\n        \"txID\": \"2HHr7xUJgWiLESV7g8T3oWfWvdpWJXd4Hctj6U3KhzUN6EsgBG\"\n    }\n}",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"id\": 1,\n    \"method\": \"avm.getTxStatus\",\n    \"params\": {\n        \"txID\": \"{{txID}}\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -857,7 +829,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.getUTXOs\",\n    \"params\" :{\n        \"addresses\":[\"{{xchainAddress}}\"],\n        \"limit\": 5,\n        \"sourceChain\": \"X\",\n        \"encoding\": \"hex\"\n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.getUTXOs\",\n    \"params\" :{\n        \"addresses\":[\"{{xchainAddress}}\"],\n        \"limit\": 5,\n        \"sourceChain\": \"X\",\n        \"encoding\": \"hex\",\n        \"startIndex\": { \n            \"address\": \"{{xchainAddress}}\",\n            \"utxo\": \"{{utxo}}\"\n        }\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -909,13 +881,13 @@
 					"response": []
 				},
 				{
-					"name": "importAVAX",
+					"name": "importKey",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.importAVAX\",\n    \"params\" :{\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"sourceChain\": \"C\",\n        \"to\":\"{{xchainAddress}}\"\n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.importKey\",\n    \"params\" :{\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\",\n        \"privateKey\":\"{{privkey}}\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -933,7 +905,7 @@
 								"X"
 							]
 						},
-						"description": "Finalize a transfer of AVAX from either the P-Chain to the X-Chain or the C-Chain to the X-Chain.\n\nBefore this method is called, you must call either the P-Chain’s `exportAVAX` method or the C-Chain’s `exportAVAX` method to initiate the transfer. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-importavax)"
+						"description": "Give a user control over an address by providing the private key that controls the address. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-importkey)"
 					},
 					"response": []
 				},
@@ -963,35 +935,6 @@
 							]
 						},
 						"description": "Send a signed transaction to the network. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-issuetx)"
-					},
-					"response": []
-				},
-				{
-					"name": "importKey",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.importKey\",\n    \"params\" :{\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\",\n        \"privateKey\":\"{{privkey}}\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/X",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"X"
-							]
-						},
-						"description": "Give a user control over an address by providing the private key that controls the address. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-importkey)"
 					},
 					"response": []
 				},
@@ -1112,35 +1055,6 @@
 					"response": []
 				},
 				{
-					"name": "sendAsManager",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.sendAsManager\",\n    \"params\" :{ \n        \"assetID\" : \"{{avaxAssetId}}\",\n        \"amount\"  : 2000000,\n        \"feeFrom\": [\"{{xchainAddress}}\"],\n        \"feeChangeAddr\": \"{{xchainAddress}}\",\n        \"from\"    : [\"{{xchainAddress}}\"],\n        \"to\"      : \"{{xchainAddress}}\",\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"memo\"    : \"{{memo}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\" \n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/X",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"X"
-							]
-						},
-						"description": "Send a quantity of an asset to an address. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-send)"
-					},
-					"response": []
-				},
-				{
 					"name": "sendMultiple",
 					"request": {
 						"method": "POST",
@@ -1195,35 +1109,6 @@
 							]
 						},
 						"description": "Send a quantity of an asset to an address. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-sendnft)"
-					},
-					"response": []
-				},
-				{
-					"name": "updateManagedAsset",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.updateManagedAsset\",\n    \"params\" :{ \n        \"assetID\" : {{avaxAssetId}},\n        \"frozen\": true,\n        \"manager\":{\n            \"threshold\": 1,\n            \"addresses\": [\n                \"{{xchainAddress}}\"\n            ]\n        },\n        \"from\"    : [\"{{xchainAddress}}\"],\n        \"to\"      : \"{{xchainAddress}}\",\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"memo\"    : \"{{memo}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\" \n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/X",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"X"
-							]
-						},
-						"description": "Send a quantity of an asset to an address. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-send)"
 					},
 					"response": []
 				}
@@ -2237,13 +2122,13 @@
 					"name": "X-Chain Transactions",
 					"item": [
 						{
-							"name": "getLastAccepted",
+							"name": "getContainerByID",
 							"request": {
 								"method": "POST",
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getLastAccepted\",\n    \"params\": {\n        \"encoding\":\"hex\"\n    }\n}",
+									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerByID\",\n    \"params\": {\n        \"containerID\":\"2dGz8JSfX17QqW12pARrt2iWNhXdcpXMYPVSYRn9HrReGpMXqQ\",\n        \"encoding\":\"hex\"\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -2262,7 +2147,7 @@
 										"tx"
 									]
 								},
-								"description": "Get the most recently accepted container. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getlastaccepted)"
+								"description": "Get container by ID. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getcontainerbyid)"
 							},
 							"response": []
 						},
@@ -2293,36 +2178,6 @@
 									]
 								},
 								"description": "Get container by index. The first container accepted is at index 0, the second is at index 1, etc. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getcontainerbyindex)"
-							},
-							"response": []
-						},
-						{
-							"name": "getContainerByID",
-							"request": {
-								"method": "POST",
-								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerByID\",\n    \"params\": {\n        \"containerID\":\"2dGz8JSfX17QqW12pARrt2iWNhXdcpXMYPVSYRn9HrReGpMXqQ\",\n        \"encoding\":\"hex\"\n    }\n}",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
-								"url": {
-									"raw": "{{baseURL}}/ext/index/X/tx",
-									"host": [
-										"{{baseURL}}"
-									],
-									"path": [
-										"ext",
-										"index",
-										"X",
-										"tx"
-									]
-								},
-								"description": "Get container by ID. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getcontainerbyid)"
 							},
 							"response": []
 						},
@@ -2387,6 +2242,36 @@
 							"response": []
 						},
 						{
+							"name": "getLastAccepted",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getLastAccepted\",\n    \"params\": {\n        \"encoding\":\"hex\"\n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseURL}}/ext/index/X/tx",
+									"host": [
+										"{{baseURL}}"
+									],
+									"path": [
+										"ext",
+										"index",
+										"X",
+										"tx"
+									]
+								},
+								"description": "Get the most recently accepted container. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getlastaccepted)"
+							},
+							"response": []
+						},
+						{
 							"name": "isAccepted",
 							"request": {
 								"method": "POST",
@@ -2422,13 +2307,13 @@
 					"name": "X-Chain Vertices",
 					"item": [
 						{
-							"name": "getLastAccepted",
+							"name": "getContainerByID",
 							"request": {
 								"method": "POST",
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getLastAccepted\",\n    \"params\": {\n        \"encoding\":\"hex\"\n    }\n}",
+									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerByID\",\n    \"params\": {\n        \"containerID\":\"8JeLjRDCojGAZXYNvLDxeU7XhKaTiMzJsSEue7d37kA1n1Htm\",\n        \"encoding\":\"hex\"\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -2447,7 +2332,7 @@
 										"vtx"
 									]
 								},
-								"description": "Get the most recently accepted container. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getlastaccepted)"
+								"description": "Get container by ID. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getcontainerbyid)"
 							},
 							"response": []
 						},
@@ -2478,36 +2363,6 @@
 									]
 								},
 								"description": "Get container by index. The first container accepted is at index 0, the second is at index 1, etc. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getcontainerbyindex)"
-							},
-							"response": []
-						},
-						{
-							"name": "getContainerByID",
-							"request": {
-								"method": "POST",
-								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerByID\",\n    \"params\": {\n        \"containerID\":\"8JeLjRDCojGAZXYNvLDxeU7XhKaTiMzJsSEue7d37kA1n1Htm\",\n        \"encoding\":\"hex\"\n    }\n}",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
-								"url": {
-									"raw": "{{baseURL}}/ext/index/X/vtx",
-									"host": [
-										"{{baseURL}}"
-									],
-									"path": [
-										"ext",
-										"index",
-										"X",
-										"vtx"
-									]
-								},
-								"description": "Get container by ID. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getcontainerbyid)"
 							},
 							"response": []
 						},
@@ -2572,6 +2427,36 @@
 							"response": []
 						},
 						{
+							"name": "getLastAccepted",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getLastAccepted\",\n    \"params\": {\n        \"encoding\":\"hex\"\n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseURL}}/ext/index/X/vtx",
+									"host": [
+										"{{baseURL}}"
+									],
+									"path": [
+										"ext",
+										"index",
+										"X",
+										"vtx"
+									]
+								},
+								"description": "Get the most recently accepted container. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getlastaccepted)"
+							},
+							"response": []
+						},
+						{
 							"name": "isAccepted",
 							"request": {
 								"method": "POST",
@@ -2607,13 +2492,13 @@
 					"name": "P-Chain Blocks",
 					"item": [
 						{
-							"name": "getLastAccepted",
+							"name": "getContainerByID",
 							"request": {
 								"method": "POST",
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getLastAccepted\",\n    \"params\": {\n        \"encoding\":\"hex\"\n    }\n}",
+									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerByID\",\n    \"params\": {\n        \"containerID\":\"8JeLjRDCojGAZXYNvLDxeU7XhKaTiMzJsSEue7d37kA1n1Htm\",\n        \"encoding\":\"hex\"\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -2632,7 +2517,7 @@
 										"block"
 									]
 								},
-								"description": "Get the most recently accepted container. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getlastaccepted)"
+								"description": "Get container by ID. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getcontainerbyid)"
 							},
 							"response": []
 						},
@@ -2663,36 +2548,6 @@
 									]
 								},
 								"description": "Get container by index. The first container accepted is at index 0, the second is at index 1, etc. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getcontainerbyindex)"
-							},
-							"response": []
-						},
-						{
-							"name": "getContainerByID",
-							"request": {
-								"method": "POST",
-								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerByID\",\n    \"params\": {\n        \"containerID\":\"8JeLjRDCojGAZXYNvLDxeU7XhKaTiMzJsSEue7d37kA1n1Htm\",\n        \"encoding\":\"hex\"\n    }\n}",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
-								"url": {
-									"raw": "{{baseURL}}/ext/index/P/block",
-									"host": [
-										"{{baseURL}}"
-									],
-									"path": [
-										"ext",
-										"index",
-										"P",
-										"block"
-									]
-								},
-								"description": "Get container by ID. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getcontainerbyid)"
 							},
 							"response": []
 						},
@@ -2753,6 +2608,36 @@
 									]
 								},
 								"description": "Get a container's index. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getindex)"
+							},
+							"response": []
+						},
+						{
+							"name": "getLastAccepted",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getLastAccepted\",\n    \"params\": {\n        \"encoding\":\"hex\"\n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseURL}}/ext/index/P/block",
+									"host": [
+										"{{baseURL}}"
+									],
+									"path": [
+										"ext",
+										"index",
+										"P",
+										"block"
+									]
+								},
+								"description": "Get the most recently accepted container. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getlastaccepted)"
 							},
 							"response": []
 						},
@@ -2792,13 +2677,13 @@
 					"name": "C-Chain Blocks",
 					"item": [
 						{
-							"name": "getLastAccepted",
+							"name": "getContainerByID",
 							"request": {
 								"method": "POST",
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getLastAccepted\",\n    \"params\": {\n        \"encoding\":\"hex\"\n    }\n}",
+									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerByID\",\n    \"params\": {\n        \"containerID\":\"8JeLjRDCojGAZXYNvLDxeU7XhKaTiMzJsSEue7d37kA1n1Htm\",\n        \"encoding\":\"hex\"\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -2817,7 +2702,7 @@
 										"block"
 									]
 								},
-								"description": "Get the most recently accepted container. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getlastaccepted)"
+								"description": "Get container by ID. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getcontainerbyid)"
 							},
 							"response": []
 						},
@@ -2848,36 +2733,6 @@
 									]
 								},
 								"description": "Get container by index. The first container accepted is at index 0, the second is at index 1, etc. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getcontainerbyindex)"
-							},
-							"response": []
-						},
-						{
-							"name": "getContainerByID",
-							"request": {
-								"method": "POST",
-								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerByID\",\n    \"params\": {\n        \"containerID\":\"8JeLjRDCojGAZXYNvLDxeU7XhKaTiMzJsSEue7d37kA1n1Htm\",\n        \"encoding\":\"hex\"\n    }\n}",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
-								"url": {
-									"raw": "{{baseURL}}/ext/index/C/block",
-									"host": [
-										"{{baseURL}}"
-									],
-									"path": [
-										"ext",
-										"index",
-										"C",
-										"block"
-									]
-								},
-								"description": "Get container by ID. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getcontainerbyid)"
 							},
 							"response": []
 						},
@@ -2938,6 +2793,36 @@
 									]
 								},
 								"description": "Get a container's index. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getindex)"
+							},
+							"response": []
+						},
+						{
+							"name": "getLastAccepted",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getLastAccepted\",\n    \"params\": {\n        \"encoding\":\"hex\"\n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseURL}}/ext/index/C/block",
+									"host": [
+										"{{baseURL}}"
+									],
+									"path": [
+										"ext",
+										"index",
+										"C",
+										"block"
+									]
+								},
+								"description": "Get the most recently accepted container. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getlastaccepted)"
 							},
 							"response": []
 						},
@@ -2979,6 +2864,34 @@
 		{
 			"name": "Info",
 			"item": [
+				{
+					"name": "isBootstrapped",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"info.isBootstrapped\",\n    \"params\": {\n        \"chain\": \"X\"\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseURL}}/ext/info",
+							"host": [
+								"{{baseURL}}"
+							],
+							"path": [
+								"ext",
+								"info"
+							]
+						},
+						"description": "Check whether a given chain is done bootstrapping. [More info](https://docs.avax.network/build/avalanchego-apis/info-api#infoisbootstrapped)"
+					},
+					"response": []
+				},
 				{
 					"name": "getBlockchainID",
 					"request": {
@@ -3148,34 +3061,6 @@
 					"response": []
 				},
 				{
-					"name": "isBootstrapped",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"info.isBootstrapped\",\n    \"params\": {\n        \"chain\": \"X\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/info",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"info"
-							]
-						},
-						"description": "Check whether a given chain is done bootstrapping. [More info](https://docs.avax.network/build/avalanchego-apis/info-api#infoisbootstrapped)"
-					},
-					"response": []
-				},
-				{
 					"name": "getTxFee",
 					"request": {
 						"method": "POST",
@@ -3232,34 +3117,6 @@
 					"response": []
 				},
 				{
-					"name": "uptime",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"info.uptime\"\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/info",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"info"
-							]
-						},
-						"description": "Returns the network's observed uptime of this node. [More info](https://docs.avax.network/build/avalanchego-apis/info-api#info-uptime)"
-					},
-					"response": []
-				},
-				{
 					"name": "peers",
 					"request": {
 						"method": "POST",
@@ -3284,6 +3141,34 @@
 							]
 						},
 						"description": "Get description of peer connections. [More info](https://docs.avax.network/build/apis/info-api#info-peers)"
+					},
+					"response": []
+				},
+				{
+					"name": "uptime",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"info.uptime\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseURL}}/ext/info",
+							"host": [
+								"{{baseURL}}"
+							],
+							"path": [
+								"ext",
+								"info"
+							]
+						},
+						"description": "Returns the network's observed uptime of this node. [More info](https://docs.avax.network/build/avalanchego-apis/info-api#info-uptime)"
 					},
 					"response": []
 				}
@@ -3537,7 +3422,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.addDelegator\",\n    \"params\": {\n        \"nodeId\":\"{{avalancheNodeId}}\",\n        \"startTime\":1613347036,\n        \"endTime\":1631215800,\n        \"stakeAmount\":200000000000,\n        \"rewardAddress\": \"{{pchainAddress}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.addDelegator\",\n    \"params\": {\n        \"nodeId\":\"{{avalancheNodeId}}\",\n        \"startTime\":1613347036,\n        \"endTime\":1631215800,\n        \"stakeAmount\":200000000000,\n        \"rewardAddress\": \"{{pchainAddress}}\",\n        \"from\": [\"{{pchainAddress}}\"],\n        \"changeAddr\": \"{{pchainAddress}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -3560,42 +3445,13 @@
 					"response": []
 				},
 				{
-					"name": "addValidator",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.addValidator\",\n    \"params\": {\n        \"nodeID\":\"{{avalancheNodeId}}\",\n        \"startTime\":1606245174,\n        \"endTime\":1608837056,\n        \"stakeAmount\":2000000000000,\n        \"rewardAddress\": \"{{pchainAddress}}\",\n        \"delegationFeeRate\":10,\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "Add a validator to the Default Subnet. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformadddefaultsubnetvalidator)"
-					},
-					"response": []
-				},
-				{
 					"name": "addSubnetValidator",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.addSubnetValidator\",\n    \"params\": {\n        \"nodeID\":\"{{avalancheNodeId}}\",\n        \"subnetID\":\"{{avalancheSubnetId}}\",\n        \"startTime\":1625782598,\n        \"endTime\":1627078419,\n        \"weight\":20,\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.addSubnetValidator\",\n    \"params\": {\n        \"nodeID\":\"{{avalancheNodeId}}\",\n        \"subnetID\":\"{{avalancheSubnetId}}\",\n        \"startTime\":1625782598,\n        \"endTime\":1627078419,\n        \"weight\":20,\n        \"from\": [\"{{pchainAddress}}\"],\n        \"changeAddr\": \"{{pchainAddress}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -3614,6 +3470,35 @@
 							]
 						},
 						"description": "Add a validator to a Subnet other than the Default Subnet. The validator must validate the Default Subnet for the entire duration they validate this Subnet. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformaddnondefaultsubnetvalidator)"
+					},
+					"response": []
+				},
+				{
+					"name": "addValidator",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.addValidator\",\n    \"params\": {\n        \"nodeID\":\"{{avalancheNodeId}}\",\n        \"startTime\":1606245174,\n        \"endTime\":1608837056,\n        \"stakeAmount\":2000000000000,\n        \"rewardAddress\": \"{{pchainAddress}}\",\n        \"delegationFeeRate\":10,\n        \"from\": [\"{{pchainAddress}}\"],\n        \"changeAddr\": \"{{pchainAddress}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseURL}}/ext/bc/P",
+							"host": [
+								"{{baseURL}}"
+							],
+							"path": [
+								"ext",
+								"bc",
+								"P"
+							]
+						},
+						"description": "Add a validator to the Default Subnet. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformadddefaultsubnetvalidator)"
 					},
 					"response": []
 				},
@@ -3653,7 +3538,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.createBlockchain\",\n    \"params\" : {\n        \"vmID\":\"avm\",\n        \"SubnetID\":\"{{avalancheSubnetId}}\",\n        \"name\":\"My new avm\",\n        \"genesisData\": \"111115LHK2ZCYttSKPmmhsTDSuKiCkmHz65nUS1YqybvjirwGLLt376k1RwnTt72WobPqrG7rmgrKVqSq6VxDsKXYGnRmfhdLCEhsYjM\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.createBlockchain\",\n    \"params\" : {\n        \"vmID\":\"avm\",\n        \"SubnetID\":\"{{avalancheSubnetId}}\",\n        \"name\":\"My new avm\",\n        \"genesisData\": \"111115LHK2ZCYttSKPmmhsTDSuKiCkmHz65nUS1YqybvjirwGLLt376k1RwnTt72WobPqrG7rmgrKVqSq6VxDsKXYGnRmfhdLCEhsYjM\",\n        \"encoding\": \"hex\",\n        \"from\": [\"{{pchainAddress}}\"],\n        \"changeAddr\": \"{{pchainAddress}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -3705,13 +3590,71 @@
 					"response": []
 				},
 				{
+					"name": "exportAVAX",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.exportAVAX\",\n    \"params\": {\n        \"to\":\"{{xchainAddress}}\",\n        \"amount\":54321,\n        \"from\": [\"{{pchainAddress}}\"],\n        \"changeAddr\": \"{{pchainAddress}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseURL}}/ext/bc/P",
+							"host": [
+								"{{baseURL}}"
+							],
+							"path": [
+								"ext",
+								"bc",
+								"P"
+							]
+						},
+						"description": "Send AVAX from an account on the C-Chain to an address on the X-Chain.\nThis transaction must be signed with the key of the account that the AVAX is sent from and which pays the transaction fee.\nAfter issuing this transaction, you must call the X-Chain’s `importAVA` method to complete the transfer. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformexportavax)"
+					},
+					"response": []
+				},
+				{
+					"name": "exportKey",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.exportKey\",\n    \"params\" :{\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\",\n        \"address\": \"{{pchainAddress}}\"\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseURL}}/ext/bc/P",
+							"host": [
+								"{{baseURL}}"
+							],
+							"path": [
+								"ext",
+								"bc",
+								"P"
+							]
+						},
+						"description": "Get the private key that controls a given address.\nThe returned private key can be added to a user with `platform.importKey`. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformexportkey)"
+					},
+					"response": []
+				},
+				{
 					"name": "getBalance",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getBalance\",\n    \"params\" :{\n      \"address\":\"P-custom1u6eth2fg33ye63mnyu5jswtj326jaypvhyar45\"    \n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getBalance\",\n    \"params\" :{\n      \"addresses\":[\"{{pchainAddress}}\"]    \n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -3734,13 +3677,13 @@
 					"response": []
 				},
 				{
-					"name": "getBlockchains",
+					"name": "getBlock",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.getBlockchains\",\n    \"params\": {},\n    \"id\": 1\n}",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.getBlock\",\n    \"params\": {\n        \"blockID\": \"{{blockID}}\",\n        \"encoding\": \"hex\"\n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -3758,12 +3701,12 @@
 								"P"
 							]
 						},
-						"description": "Get all the blockchains that exist (excluding the P-Chain). [More info](https://docs.avax.network/v1.0/en/api/platform/#platformgetblockchains)"
+						"description": "Get a block by its ID. [More info](https://docs.avax.network/apis/avalanchego/apis/p-chain#platformgetblock)"
 					},
 					"response": []
 				},
 				{
-					"name": "timestamp",
+					"name": "getBlockchains",
 					"request": {
 						"method": "POST",
 						"header": [],
@@ -3827,7 +3770,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getCurrentSupply\",\n    \"params\": {}\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getCurrentSupply\",\n    \"params\": {\n        \"subnetID\": \"{{avalancheSubnetId}}\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -3850,35 +3793,6 @@
 					"response": []
 				},
 				{
-					"name": "getTotalStake",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getTotalStake\",\n    \"params\": {}\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "Get the total amount of nAVAX staked on the Primary Network. [More info](https://docs.avax.network/build/avalanchego-apis/p-chain#platformgettotalstake)"
-					},
-					"response": []
-				},
-				{
 					"name": "getCurrentValidators",
 					"request": {
 						"method": "POST",
@@ -3886,35 +3800,6 @@
 						"body": {
 							"mode": "raw",
 							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.getCurrentValidators\",\n    \"params\": {\n        \"subnetID\":null,\n        \"nodeIDs\":[]\n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "List the current validators of the given Subnet. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformgetcurrentvalidators)"
-					},
-					"response": []
-				},
-				{
-					"name": "getMaxStakeAmount",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.getMaxStakeAmount\",\n    \"params\": {\n        \"subnetID\":\"\",\n        \"nodeID\":\"\",\n        \"startTime\": 123,\n        \"endTime\": 321\n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -3966,13 +3851,42 @@
 					"response": []
 				},
 				{
+					"name": "getMaxStakeAmount",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.getMaxStakeAmount\",\n    \"params\": {\n        \"subnetID\":\"\",\n        \"nodeID\":\"\",\n        \"startTime\": 123,\n        \"endTime\": 321\n    },\n    \"id\": 1\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseURL}}/ext/bc/P",
+							"host": [
+								"{{baseURL}}"
+							],
+							"path": [
+								"ext",
+								"bc",
+								"P"
+							]
+						},
+						"description": "List the current validators of the given Subnet. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformgetcurrentvalidators)"
+					},
+					"response": []
+				},
+				{
 					"name": "getMinStake",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getMinStake\",\n    \"params\": {}\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getMinStake\",\n    \"params\": {\n        \"subnetID\": \"{{avalancheSubnetId}}\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -3991,6 +3905,35 @@
 							]
 						},
 						"description": "Returns the minimum stake amount [More info](https://docs.avax.network/v1.0/en/api/platform/#platformgetminstake)"
+					},
+					"response": []
+				},
+				{
+					"name": "getPendingValidators",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.getPendingValidators\",\n    \"params\": {\n        \"subnetID\": null,\n        \"nodeIDs\": []\n    },\n    \"id\": 1\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseURL}}/ext/bc/P",
+							"host": [
+								"{{baseURL}}"
+							],
+							"path": [
+								"ext",
+								"bc",
+								"P"
+							]
+						},
+						"description": "List the validators in the pending validator set of the specified Subnet. Each validator is not currently validating the Subnet but will in the future. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformgetpendingvalidators)"
 					},
 					"response": []
 				},
@@ -4053,71 +3996,13 @@
 					"response": []
 				},
 				{
-					"name": "getTxStatus",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.getTxStatus\",\n    \"params\": {\n        \"txID\": \"23CLURk1Czf1aLui1VdcuWSiDeFskfp3Sn8TQG7t6NKfeQRYDj\",\n        \"includeReason\": true\n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "Returns the status of a platform chain transaction."
-					},
-					"response": []
-				},
-				{
-					"name": "getPendingValidators",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.getPendingValidators\",\n    \"params\": {\n        \"subnetID\": null,\n        \"nodeIDs\": []\n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "List the validators in the pending validator set of the specified Subnet. Each validator is not currently validating the Subnet but will in the future. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformgetpendingvalidators)"
-					},
-					"response": []
-				},
-				{
 					"name": "getStakingAssetID",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getStakingAssetID\",\n    \"params\": {}\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getStakingAssetID\",\n    \"params\": {\n        \"subnetID\": \"{{avalancheSubnetId}}\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -4146,7 +4031,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.getSubnets\",\n    \"params\": {},\n    \"id\": 1\n}",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.getSubnets\",\n    \"params\": {\n        \"ids\": [\"{{avalancheSubnetId}}\"]\n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -4169,13 +4054,13 @@
 					"response": []
 				},
 				{
-					"name": "getTx",
+					"name": "getTimestamp",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getTx\",\n    \"params\" :{\n        \"txID\":\"Cy7cZUot6DCUUDz1VuA2C7vFVWSzW3DgLhYXUAiLWH8BKafbH\",\n        \"encoding\": \"hex\"\n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getTimestamp\",\n    \"params\" :{}\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -4198,13 +4083,42 @@
 					"response": []
 				},
 				{
-					"name": "getTimestamp",
+					"name": "getTotalStake",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getTimestamp\",\n    \"params\" :{}\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getTotalStake\",\n    \"params\": {\n        \"subnetID\": \"{{avalancheSubnetId}}\"\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseURL}}/ext/bc/P",
+							"host": [
+								"{{baseURL}}"
+							],
+							"path": [
+								"ext",
+								"bc",
+								"P"
+							]
+						},
+						"description": "Get the total amount of nAVAX staked on the Primary Network. [More info](https://docs.avax.network/build/avalanchego-apis/p-chain#platformgettotalstake)"
+					},
+					"response": []
+				},
+				{
+					"name": "getTx",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getTx\",\n    \"params\" :{\n        \"txID\":\"Cy7cZUot6DCUUDz1VuA2C7vFVWSzW3DgLhYXUAiLWH8BKafbH\",\n        \"encoding\": \"hex\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -4262,7 +4176,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getUTXOs\",\n    \"params\" :{\n        \"addresses\":[\"P-custom18jma8ppw3nhx5r4ap8clazz0dps7rv5u9xde7p\"],\n        \"sourceChain\": \"X\",\n        \"limit\": 5,\n        \"encoding\": \"hex\"\n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getUTXOs\",\n    \"params\" :{\n        \"addresses\":[\"{{pchainAddress}}\"],\n        \"sourceChain\": \"P\",\n        \"limit\": 5,\n        \"encoding\": \"hex\",\n        \"startIndex\": {\n            \"address\": \"{{pchainAddress}}\",\n            \"utxo\": \"LUC1cmcxnfNR9LdkACS2ccGKLEK7SYqB4gLLTycQfg1koyfSq\"\n        }\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -4291,7 +4205,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getValidatorsAt\",\n    \"params\" :{\n        \"height\": 0,\n        \"subnetID\": \"11111111111111111111111111111111LpoYY\"\n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getValidatorsAt\",\n    \"params\" :{\n        \"height\": 0,\n        \"subnetID\": \"{{avalancheSubnetId}}\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -4314,71 +4228,13 @@
 					"response": []
 				},
 				{
-					"name": "exportAVAX",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.exportAVAX\",\n    \"params\": {\n        \"to\":\"{{xchainAddress}}\",\n        \"amount\":54321,\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "Send AVAX from an account on the C-Chain to an address on the X-Chain.\nThis transaction must be signed with the key of the account that the AVAX is sent from and which pays the transaction fee.\nAfter issuing this transaction, you must call the X-Chain’s `importAVA` method to complete the transfer. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformexportavax)"
-					},
-					"response": []
-				},
-				{
-					"name": "exportKey",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.exportKey\",\n    \"params\" :{\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\",\n        \"address\": \"{{pchainAddress}}\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{baseURL}}/ext/bc/P",
-							"host": [
-								"{{baseURL}}"
-							],
-							"path": [
-								"ext",
-								"bc",
-								"P"
-							]
-						},
-						"description": "Get the private key that controls a given address.\nThe returned private key can be added to a user with `platform.importKey`. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformexportkey)"
-					},
-					"response": []
-				},
-				{
 					"name": "importAVAX",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.importAVAX\",\n    \"params\": {\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"sourceChain\": \"X\",\n        \"to\":\"{{pchainAddress}}\"\n    },\n    \"id\": 1\n}",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.importAVAX\",\n    \"params\": {\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"sourceChain\": \"X\",\n        \"to\":\"{{pchainAddress}}\",\n        \"from\": [\"{{pchainAddress}}\"],\n        \"changeAddr\": \"{{pchainAddress}}\"\n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"

--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -2646,7 +2646,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getStakingAssetID\",\n    \"params\": {}\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getHeight\",\n    \"params\": {}\n}",
 							"options": {
 								"raw": {
 									"language": "json"

--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -2401,7 +2401,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
+							"raw": "{{http}}://{{host}}:{{port}}/ext/P",
 							"protocol": "{{http}}",
 							"host": [
 								"{{host}}"
@@ -2409,7 +2409,6 @@
 							"port": "{{port}}",
 							"path": [
 								"ext",
-								"bc",
 								"P"
 							]
 						},
@@ -2432,15 +2431,14 @@
 							}
 						},
 						"url": {
-							"raw": "http://localhost:9650/ext/bc/P",
-							"protocol": "http",
+							"raw": "{{http}}://{{host}}:{{port}}/ext/P",
+							"protocol": "{{http}}",
 							"host": [
-								"localhost"
+								"{{host}}"
 							],
-							"port": "9650",
+							"port": "{{port}}",
 							"path": [
 								"ext",
-								"bc",
 								"P"
 							]
 						},

--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "e2bf7d02-bde8-4c54-af75-b15ad7922a01",
+		"_postman_id": "72e39b9d-49f8-416f-89db-118fcb994d21",
 		"name": "Avalanche",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -1707,13 +1707,13 @@
 					"response": []
 				},
 				{
-					"name": "getTxStatus",
+					"name": "getAtomicTxStatus",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"id\": 1,\n    \"method\": \"avax.getTxStatus\",\n    \"params\": {\n        \"txID\": \"2LVVdbsbg7Lkp3bVBzbJeopp8HfBMApefoHLZ7VaFkXPPvd7KJ\"\n    }\n}",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"id\": 1,\n    \"method\": \"avax.getAtomicTxStatus\",\n    \"params\": {\n        \"txID\": \"2LVVdbsbg7Lkp3bVBzbJeopp8HfBMApefoHLZ7VaFkXPPvd7KJ\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"

--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -83,12 +83,12 @@
 							}
 						},
 						"url": {
-							"raw": "http://localhost:9650/ext/admin",
-							"protocol": "http",
+							"raw": "{{http}}://{{host}}:{{port}}/ext/admin",
+							"protocol": "{{http}}",
 							"host": [
-								"localhost"
+								"{{host}}"
 							],
-							"port": "9650",
+							"port": "{{port}}",
 							"path": [
 								"ext",
 								"admin"
@@ -165,7 +165,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"admin.stopCPUProfiler\"\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"admin.stopCPUProfiler\",\n    \"params\" :{\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1775,7 +1775,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"info.getNetworkID\"\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"info.getNetworkID\",\n    \"params\" :{\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1805,7 +1805,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"info.getNetworkName\"\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"info.getNetworkName\",\n    \"params\" :{\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1835,7 +1835,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"info.getNodeID\"\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"info.getNodeID\",\n    \"params\" :{\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1865,7 +1865,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"info.getNodeVersion\"\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"info.getNodeVersion\",\n    \"params\" :{\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1955,7 +1955,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"info.peers\"\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"info.peers\",\n    \"params\" :{\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"

--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -730,7 +730,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.getTx\",\n    \"params\" :{\n        \"txID\":\"2QouvFWUbjuySRxeX5xMbNCuAaKWfbk5FeEa2JmoF85RKLk2dD\"\n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.getTx\",\n    \"params\" :{\n        \"txID\":\"2QouvFWUbjuySRxeX5xMbNCuAaKWfbk5FeEa2JmoF85RKLk2dD\",\n        \"encoding\": \"hex\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1745,7 +1745,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avax.getAtomicTx\",\n    \"params\" :{\n        \"txID\":\"n1D9UkjiryEBtW8qznD1TDkGEuYRFj5tLaS8NhVpMLYsx1FHa\"\n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avax.getAtomicTx\",\n    \"params\" :{\n        \"txID\":\"2GD5SRYJQr2kw5jE73trBFiAgVQyrCaeg223TaTyJFYXf2kPty\",\n        \"encoding\": \"cb58\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -4082,7 +4082,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getTx\",\n    \"params\" :{\n        \"txID\":\"LK5gemsUXLQEuAjq37iGct2E5GC72KKLZxaVoDF7foQiSY6mu\"\n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getTx\",\n    \"params\" :{\n        \"txID\":\"Cy7cZUot6DCUUDz1VuA2C7vFVWSzW3DgLhYXUAiLWH8BKafbH\",\n        \"encoding\": \"cb58\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"

--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -2739,7 +2739,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.getTxStatus\",\n    \"params\": {\n        \"txID\": \"23CLURk1Czf1aLui1VdcuWSiDeFskfp3Sn8TQG7t6NKfeQRYDj\"\n    },\n    \"id\": 1\n}",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.getTxStatus\",\n    \"params\": {\n        \"txID\": \"23CLURk1Czf1aLui1VdcuWSiDeFskfp3Sn8TQG7t6NKfeQRYDj\",\n        \"includeReason\": true\n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"

--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -2708,7 +2708,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getStake\",\n    \"params\": {\n        \"addresses\": [{{pchainAddress}}]\n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getStake\",\n    \"params\": {\n        \"addresses\": [\"{{pchainAddress}}\"]\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"

--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -1127,7 +1127,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"ava.exportAVAX\",\n    \"params\": {\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"to\":\"c876DF0F099b3eb32cBB78820d39F5813f73E18C\"\n    },\n    \"id\": 1\n}",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"ava.exportAVAX\",\n    \"params\": {\n        \"to\":\"{{xchainAddress}}\",\n        \"amount\": 99000000,\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"

--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -1096,7 +1096,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"ava.importAVAX\",\n    \"params\": {\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"sourceChain\": \"jnUjZSRt16TcRnZzmh5aMhavwVHz3zBrSN8GfFMTQkzUnoBxC\",\n        \"to\":\"c876DF0F099b3eb32cBB78820d39F5813f73E18C\"\n    },\n    \"id\": 1\n}",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"ava.importAVAX\",\n    \"params\": {\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"sourceChain\": \"X\",\n        \"to\":\"0x4b879aff6b3d24352Ac1985c1F45BA4c3493A398\"\n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1121,13 +1121,13 @@
 					"response": []
 				},
 				{
-					"name": "ExportAVAX",
+					"name": "exportAVAX",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"ava.importAVAX\",\n    \"params\": {\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"sourceChain\": \"jnUjZSRt16TcRnZzmh5aMhavwVHz3zBrSN8GfFMTQkzUnoBxC\",\n        \"to\":\"c876DF0F099b3eb32cBB78820d39F5813f73E18C\"\n    },\n    \"id\": 1\n}",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"ava.exportAVAX\",\n    \"params\": {\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"to\":\"c876DF0F099b3eb32cBB78820d39F5813f73E18C\"\n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1189,7 +1189,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"ava.exportKey\",\n    \"params\": {\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"address\":\"{{cchainAddress}}\"\n    },\n    \"id\": 1\n}",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"ava.importKey\",\n    \"params\": {\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"privateKey\":\"{{cchainAddress}}\"\n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1962,7 +1962,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{   \n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"keystore.createUser\",\n    \"params\" :{\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"keystore.createUser\",\n    \"params\" :{\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"

--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -69,6 +69,36 @@
 					"response": []
 				},
 				{
+					"name": "getChainAliases",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"admin.getChainAliases\",\n    \"params\" :{\n        \"chain\":\"2eNy1mUFdmaxXNj1eQHUe7Np4gju9sJsEtWQ4MX3ToiNKuADed\" \n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{http}}://{{host}}:{{port}}/ext/admin",
+							"protocol": "{{http}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"admin"
+							]
+						},
+						"description": "Dump the mutex statistics of the node to the specified file. [More info](https://docs.avax.network/build/apis/admin-api#admin-lockprofile)"
+					},
+					"response": []
+				},
+				{
 					"name": "lockProfile",
 					"request": {
 						"method": "POST",
@@ -349,6 +379,37 @@
 							]
 						},
 						"description": "Create a new address controlled by the given user. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-createaddress)"
+					},
+					"response": []
+				},
+				{
+					"name": "createAsset",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.createAsset\",\n    \"params\" :{\n        \"name\":\"myVariableCapAsset\",\n        \"symbol\":\"MFCA\",\n        \"denomination\": 0,  \n        \"minterSets\":[\n            {\n                \"minters\":[\n                    \"{{xchainAddress}}\"\n                ],\n                \"threshold\": 1\n            }\n        ],\n        \"from\": [\"{{xchainAddress}}\"],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/X",
+							"protocol": "{{http}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"bc",
+								"X"
+							]
+						},
+						"description": "Create a new variable-cap, fungible asset. No units of the asset exist at initialization. Minters can mint units of this asset using `createMintTx`, `signMintTx` and `issueTx`. The asset can be sent with `avm.send`. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-createvariablecapasset)"
 					},
 					"response": []
 				},
@@ -1004,6 +1065,37 @@
 					"response": []
 				},
 				{
+					"name": "sendAsManager",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.sendAsManager\",\n    \"params\" :{ \n        \"assetID\" : \"{{avaxAssetId}}\",\n        \"amount\"  : 2000000,\n        \"feeFrom\": [\"{{xchainAddress}}\"],\n        \"feeChangeAddr\": \"{{xchainAddress}}\",\n        \"from\"    : [\"{{xchainAddress}}\"],\n        \"to\"      : \"{{xchainAddress}}\",\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"memo\"    : \"{{memo}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\" \n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/X",
+							"protocol": "{{http}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"bc",
+								"X"
+							]
+						},
+						"description": "Send a quantity of an asset to an address. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-send)"
+					},
+					"response": []
+				},
+				{
 					"name": "sendMultiple",
 					"request": {
 						"method": "POST",
@@ -1062,6 +1154,37 @@
 							]
 						},
 						"description": "Send a quantity of an asset to an address. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-sendnft)"
+					},
+					"response": []
+				},
+				{
+					"name": "updateManagedAsset",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.updateManagedAsset\",\n    \"params\" :{ \n        \"assetID\" : {{avaxAssetId}},\n        \"frozen\": true,\n        \"manager\":{\n            \"threshold\": 1,\n            \"addresses\": [\n                \"{{xchainAddress}}\"\n            ]\n        },\n        \"from\"    : [\"{{xchainAddress}}\"],\n        \"to\"      : \"{{xchainAddress}}\",\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"memo\"    : \"{{memo}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\" \n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/X",
+							"protocol": "{{http}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"bc",
+								"X"
+							]
+						},
+						"description": "Send a quantity of an asset to an address. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-send)"
 					},
 					"response": []
 				}
@@ -2609,7 +2732,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.addDelegator\",\n    \"params\": {\n        \"nodeId\":\"{{avalancheNodeId}}\",\n        \"startTime\":1600406351,\n        \"endTime\":1602997371,\n        \"stakeAmount\":200000000000,\n        \"rewardAddress\": \"{{pchainAddress}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.addDelegator\",\n    \"params\": {\n        \"nodeId\":\"{{avalancheNodeId}}\",\n        \"startTime\":1613347036,\n        \"endTime\":1631215800,\n        \"stakeAmount\":200000000000,\n        \"rewardAddress\": \"{{pchainAddress}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"

--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -415,13 +415,13 @@
 					"response": []
 				},
 				{
-					"name": "createAddress",
+					"name": "createAddress - DEPRECATED",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"avm.createAddress\",\n    \"params\": {\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    },\n    \"id\": 1\n}",
+							"raw": "//Deprecated as of v1.9.12.\n\n{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"avm.createAddress\",\n    \"params\": {\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -444,13 +444,13 @@
 					"response": []
 				},
 				{
-					"name": "createAsset",
+					"name": "createAsset - DEPRECATED",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.createAsset\",\n    \"params\" :{\n        \"name\":\"myVariableCapAsset\",\n        \"symbol\":\"MFCA\",\n        \"denomination\": 0,  \n        \"minterSets\":[\n            {\n                \"minters\":[\n                    \"{{xchainAddress}}\"\n                ],\n                \"threshold\": 1\n            }\n        ],\n        \"from\": [\"{{xchainAddress}}\"],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
+							"raw": "//Deprecated as of v1.9.12.\n\n{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.createAsset\",\n    \"params\" :{\n        \"name\":\"myVariableCapAsset\",\n        \"symbol\":\"MFCA\",\n        \"denomination\": 0,  \n        \"minterSets\":[\n            {\n                \"minters\":[\n                    \"{{xchainAddress}}\"\n                ],\n                \"threshold\": 1\n            }\n        ],\n        \"from\": [\"{{xchainAddress}}\"],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -473,13 +473,13 @@
 					"response": []
 				},
 				{
-					"name": "createFixedCapAsset",
+					"name": "createFixedCapAsset - DEPRECATED",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.createFixedCapAsset\",\n    \"params\" :{\n        \"name\": \"Test Token\",\n        \"symbol\":\"TEST\",\n        \"denomination\": 0,  \n        \"initialHolders\": [\n            {\n                \"address\":\"{{xchainAddress}}\",\n                \"amount\":400\n            }\n        ],\n        \"from\": [\"{{xchainAddress}}\"],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
+							"raw": "//Deprecated as of v1.9.12.\n\n{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.createFixedCapAsset\",\n    \"params\" :{\n        \"name\": \"Test Token\",\n        \"symbol\":\"TEST\",\n        \"denomination\": 0,  \n        \"initialHolders\": [\n            {\n                \"address\":\"{{xchainAddress}}\",\n                \"amount\":400\n            }\n        ],\n        \"from\": [\"{{xchainAddress}}\"],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -502,13 +502,13 @@
 					"response": []
 				},
 				{
-					"name": "createNFTAsset",
+					"name": "createNFTAsset - DEPRECATED",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.createNFTAsset\",\n    \"params\" :{\n        \"name\":\"Coincert\",\n        \"symbol\":\"TIXX\",\n        \"minterSets\":[\n            {\n                \"minters\":[\n                    \"{{xchainAddress}}\"\n                ],\n                \"threshold\": 1\n            },\n            {\n                \"minters\":[\n                    \"{{xchainAddress}}\"\n                ],\n                \"threshold\": 1\n            }\n        ],\n        \"from\": [\"{{xchainAddress}}\"],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
+							"raw": "//Deprecated as of v1.9.12.\n\n{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.createNFTAsset\",\n    \"params\" :{\n        \"name\":\"Coincert\",\n        \"symbol\":\"TIXX\",\n        \"minterSets\":[\n            {\n                \"minters\":[\n                    \"{{xchainAddress}}\"\n                ],\n                \"threshold\": 1\n            },\n            {\n                \"minters\":[\n                    \"{{xchainAddress}}\"\n                ],\n                \"threshold\": 1\n            }\n        ],\n        \"from\": [\"{{xchainAddress}}\"],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -531,13 +531,13 @@
 					"response": []
 				},
 				{
-					"name": "createVariableCapAsset",
+					"name": "createVariableCapAsset - DEPRECATED",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.createVariableCapAsset\",\n    \"params\" :{\n        \"name\":\"myVariableCapAsset\",\n        \"symbol\":\"MFCA\",\n        \"denomination\": 0,  \n        \"minterSets\":[\n            {\n                \"minters\":[\n                    \"{{xchainAddress}}\"\n                ],\n                \"threshold\": 1\n            }\n        ],\n        \"from\": [\"{{xchainAddress}}\"],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
+							"raw": "//Deprecated as of v1.9.12.\n\n{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.createVariableCapAsset\",\n    \"params\" :{\n        \"name\":\"myVariableCapAsset\",\n        \"symbol\":\"MFCA\",\n        \"denomination\": 0,  \n        \"minterSets\":[\n            {\n                \"minters\":[\n                    \"{{xchainAddress}}\"\n                ],\n                \"threshold\": 1\n            }\n        ],\n        \"from\": [\"{{xchainAddress}}\"],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -560,13 +560,13 @@
 					"response": []
 				},
 				{
-					"name": "export",
+					"name": "export - DEPRECATED",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.export\",\n    \"params\" :{\n        \"from\": [\"{{xchainAddress}}\"],\n        \"to\":\"{{cchainbech32address}}\",\n        \"amount\": 4000001000000         ,\n        \"assetID\": \"AVAX\",\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
+							"raw": "//Deprecated as of v1.9.12.\n\n{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.export\",\n    \"params\" :{\n        \"from\": [\"{{xchainAddress}}\"],\n        \"to\":\"{{cchainbech32address}}\",\n        \"amount\": 4000001000000         ,\n        \"assetID\": \"AVAX\",\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -589,13 +589,13 @@
 					"response": []
 				},
 				{
-					"name": "exportKey",
+					"name": "exportKey - DEPRECATED",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.exportKey\",\n    \"params\" :{\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"address\": \"{{xchainAddress}}\"\n    }\n}",
+							"raw": "//Deprecated as of v1.9.12.\n\n{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.exportKey\",\n    \"params\" :{\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"address\": \"{{xchainAddress}}\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -618,13 +618,13 @@
 					"response": []
 				},
 				{
-					"name": "getAddressTxs",
+					"name": "getAddressTxs - DEPRECATED",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.getAddressTxs\",\n    \"params\" :{\n        \"address\":\"{{xchainAddress}}\",\n        \"assetID\": \"AVAX\",\n        \"pageSize\": 20,\n        \"cursor\": 0\n    }\n}",
+							"raw": "//Deprecated as of v1.9.12.\n\n{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.getAddressTxs\",\n    \"params\" :{\n        \"address\":\"{{xchainAddress}}\",\n        \"assetID\": \"AVAX\",\n        \"pageSize\": 20,\n        \"cursor\": 0\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -647,13 +647,13 @@
 					"response": []
 				},
 				{
-					"name": "getAllBalances",
+					"name": "getAllBalances - DEPRECATED",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.getAllBalances\",\n    \"params\" :{\n        \"address\":\"{{xchainAddress}}\"\n    }\n}",
+							"raw": "//Deprecated as of v1.9.12.\n\n{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.getAllBalances\",\n    \"params\" :{\n        \"address\":\"{{xchainAddress}}\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -705,33 +705,13 @@
 					"response": []
 				},
 				{
-					"name": "getBalance",
+					"name": "getBalance - DEPRECATED",
 					"event": [
 						{
 							"listen": "test",
 							"script": {
 								"exec": [
-									"var template = `",
-									"    <table bgcolor=\"#FFFFFF\">",
-									"        <tr>",
-									"            <th>Name</th>",
-									"            <th>Email</th>",
-									"        </tr>",
-									"",
-									"        {{#each response}}",
-									"            <tr>",
-									"                <td>{{name}}</td>",
-									"                <td>{{email}}</td>",
-									"            </tr>",
-									"        {{/each}}",
-									"    </table>",
-									"`;",
-									"",
-									"// Set visualizer",
-									"pm.visualizer.set(template, {",
-									"    // Pass the response body parsed as JSON as `data`",
-									"    response: pm.response.json()",
-									"});"
+									""
 								],
 								"type": "text/javascript"
 							}
@@ -742,7 +722,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"jsonrpc\":\"2.0\",\n  \"id\"     : 1,\n  \"method\" :\"avm.getBalance\",\n  \"params\" :{\n      \"address\":\"{{xchainAddress}}\",\n      \"assetID\": \"{{avaxAssetId}}\"\n  }\n} ",
+							"raw": "//Deprecated as of v1.9.12.\n\n{\n  \"jsonrpc\":\"2.0\",\n  \"id\"     : 1,\n  \"method\" :\"avm.getBalance\",\n  \"params\" :{\n      \"address\":\"{{xchainAddress}}\",\n      \"assetID\": \"{{avaxAssetId}}\"\n  }\n} ",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -771,27 +751,7 @@
 							"listen": "test",
 							"script": {
 								"exec": [
-									"var template = `",
-									"    <table bgcolor=\"#FFFFFF\">",
-									"        <tr>",
-									"            <th>Name</th>",
-									"            <th>Email</th>",
-									"        </tr>",
-									"",
-									"        {{#each response}}",
-									"            <tr>",
-									"                <td>{{name}}</td>",
-									"                <td>{{email}}</td>",
-									"            </tr>",
-									"        {{/each}}",
-									"    </table>",
-									"`;",
-									"",
-									"// Set visualizer",
-									"pm.visualizer.set(template, {",
-									"    // Pass the response body parsed as JSON as `data`",
-									"    response: pm.response.json()",
-									"});"
+									""
 								],
 								"type": "text/javascript"
 							}
@@ -831,27 +791,7 @@
 							"listen": "test",
 							"script": {
 								"exec": [
-									"var template = `",
-									"    <table bgcolor=\"#FFFFFF\">",
-									"        <tr>",
-									"            <th>Name</th>",
-									"            <th>Email</th>",
-									"        </tr>",
-									"",
-									"        {{#each response}}",
-									"            <tr>",
-									"                <td>{{name}}</td>",
-									"                <td>{{email}}</td>",
-									"            </tr>",
-									"        {{/each}}",
-									"    </table>",
-									"`;",
-									"",
-									"// Set visualizer",
-									"pm.visualizer.set(template, {",
-									"    // Pass the response body parsed as JSON as `data`",
-									"    response: pm.response.json()",
-									"});"
+									""
 								],
 								"type": "text/javascript"
 							}
@@ -891,27 +831,7 @@
 							"listen": "test",
 							"script": {
 								"exec": [
-									"var template = `",
-									"    <table bgcolor=\"#FFFFFF\">",
-									"        <tr>",
-									"            <th>Name</th>",
-									"            <th>Email</th>",
-									"        </tr>",
-									"",
-									"        {{#each response}}",
-									"            <tr>",
-									"                <td>{{name}}</td>",
-									"                <td>{{email}}</td>",
-									"            </tr>",
-									"        {{/each}}",
-									"    </table>",
-									"`;",
-									"",
-									"// Set visualizer",
-									"pm.visualizer.set(template, {",
-									"    // Pass the response body parsed as JSON as `data`",
-									"    response: pm.response.json()",
-									"});"
+									""
 								],
 								"type": "text/javascript"
 							}
@@ -1032,13 +952,13 @@
 					"response": []
 				},
 				{
-					"name": "import",
+					"name": "import - DEPRECATED",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.import\",\n    \"params\" :{\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"sourceChain\": \"P\",\n        \"to\":\"{{xchainAddress}}\"\n    }\n}",
+							"raw": "//Deprecated as of v1.9.12.\n\n{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.import\",\n    \"params\" :{\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"sourceChain\": \"P\",\n        \"to\":\"{{xchainAddress}}\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1061,13 +981,13 @@
 					"response": []
 				},
 				{
-					"name": "importKey",
+					"name": "importKey - DEPRECATED",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.importKey\",\n    \"params\" :{\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\",\n        \"privateKey\":\"{{privkey}}\"\n    }\n}",
+							"raw": "//Deprecated as of v1.9.12.\n\n{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.importKey\",\n    \"params\" :{\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\",\n        \"privateKey\":\"{{privkey}}\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1119,13 +1039,13 @@
 					"response": []
 				},
 				{
-					"name": "listAddresses",
+					"name": "listAddresses - DEPRECATED",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"avm.listAddresses\",\n    \"params\": {\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    },\n    \"id\": 1\n}",
+							"raw": "//Deprecated as of v1.9.12.\n\n{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"avm.listAddresses\",\n    \"params\": {\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1148,13 +1068,13 @@
 					"response": []
 				},
 				{
-					"name": "mint",
+					"name": "mint - DEPRECATED",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.mint\",\n    \"params\" :{\n        \"amount\": 10000000,\n        \"assetID\": \"2qnR9pLQTDZ9boSbcrcjS4n1DJJkzbkNsJzgwYvmRy8uv47fZT\",\n        \"from\": [\"{{xchainAddress}}\"],\n        \"to\": \"{{xchainAddress}}\",\n        \"minters\": [\n            \"{{xchainAddress}}\"\n        ],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\" \n    }\n}",
+							"raw": "//Deprecated as of v1.9.12.\n\n{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.mint\",\n    \"params\" :{\n        \"amount\": 10000000,\n        \"assetID\": \"2qnR9pLQTDZ9boSbcrcjS4n1DJJkzbkNsJzgwYvmRy8uv47fZT\",\n        \"from\": [\"{{xchainAddress}}\"],\n        \"to\": \"{{xchainAddress}}\",\n        \"minters\": [\n            \"{{xchainAddress}}\"\n        ],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\" \n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1177,13 +1097,13 @@
 					"response": []
 				},
 				{
-					"name": "mintNFT",
+					"name": "mintNFT - DEPRECATED",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.mintNFT\",\n    \"params\" :{\n        \"assetID\":\"2KGdt2HpFKpTH5CtGZjYt5XPWs6Pv9DLoRBhiFfntbezdRvZWP\",\n        \"payload\":\"2EWh72jYQvEJF9NLk\",\n        \"from\": [\"{{xchainAddress}}\"],\n        \"to\":\"{{xchainAddress}}\",\n        \"minters\":[\n            \"{{xchainAddress}}\"\n        ],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" ,\n        \"encoding\": \"hex\"\n    }\n}",
+							"raw": "//Deprecated as of v1.9.12.\n\n{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.mintNFT\",\n    \"params\" :{\n        \"assetID\":\"2KGdt2HpFKpTH5CtGZjYt5XPWs6Pv9DLoRBhiFfntbezdRvZWP\",\n        \"payload\":\"2EWh72jYQvEJF9NLk\",\n        \"from\": [\"{{xchainAddress}}\"],\n        \"to\":\"{{xchainAddress}}\",\n        \"minters\":[\n            \"{{xchainAddress}}\"\n        ],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" ,\n        \"encoding\": \"hex\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1206,13 +1126,13 @@
 					"response": []
 				},
 				{
-					"name": "send",
+					"name": "send - DEPRECATED",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.send\",\n    \"params\" :{ \n        \"assetID\" : \"{{avaxAssetId}}\",\n        \"amount\"  : 2000000000,\n        \"from\"    : [\"{{xchainAddress}}\"],\n        \"to\"      : \"{{xchainAddress}}\",\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"memo\"    : \"\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\" \n    }\n}",
+							"raw": "//Deprecated as of v1.9.12.\n\n{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.send\",\n    \"params\" :{ \n        \"assetID\" : \"{{avaxAssetId}}\",\n        \"amount\"  : 2000000000,\n        \"from\"    : [\"{{xchainAddress}}\"],\n        \"to\"      : \"{{xchainAddress}}\",\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"memo\"    : \"\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\" \n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1235,13 +1155,13 @@
 					"response": []
 				},
 				{
-					"name": "sendMultiple",
+					"name": "sendMultiple - DEPRECATED",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.sendMultiple\",\n    \"params\" :{ \n        \"outputs\": [\n            {\n                \"assetID\" : \"{{avaxAssetId}}\",\n                \"to\"      : \"{{xchainAddress}}\",\n                \"amount\"  : 1000000000\n            }\n        ],\n        \"from\"    : [\"{{xchainAddress}}\"],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"memo\"    : \"{{memo}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\" \n    }\n}",
+							"raw": "//Deprecated as of v1.9.12.\n\n{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.sendMultiple\",\n    \"params\" :{ \n        \"outputs\": [\n            {\n                \"assetID\" : \"{{avaxAssetId}}\",\n                \"to\"      : \"{{xchainAddress}}\",\n                \"amount\"  : 1000000000\n            }\n        ],\n        \"from\"    : [\"{{xchainAddress}}\"],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"memo\"    : \"{{memo}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\" \n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1264,13 +1184,13 @@
 					"response": []
 				},
 				{
-					"name": "sendNFT",
+					"name": "sendNFT - DEPRECATED",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.sendNFT\",\n    \"params\" :{ \n        \"assetID\" :\"2KGdt2HpFKpTH5CtGZjYt5XPWs6Pv9DLoRBhiFfntbezdRvZWP\",\n        \"from\"    : [\"{{xchainAddress}}\"],\n        \"to\"      :\"{{xchainAddress}}\",\n        \"groupID\" : 0,\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
+							"raw": "//Deprecated as of v1.9.12.\n\n{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.sendNFT\",\n    \"params\" :{ \n        \"assetID\" :\"2KGdt2HpFKpTH5CtGZjYt5XPWs6Pv9DLoRBhiFfntbezdRvZWP\",\n        \"from\"    : [\"{{xchainAddress}}\"],\n        \"to\"      :\"{{xchainAddress}}\",\n        \"groupID\" : 0,\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -3359,13 +3279,13 @@
 			"name": "IPC",
 			"item": [
 				{
-					"name": "publishBlockchain",
+					"name": "publishBlockchain - DEPRECATED",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"ipcs.publishBlockchain\",\n    \"params\":{\n        \"blockchainID\":\"{{avalanceBlockchainId}}\"\n    },\n    \"id\": 1\n}",
+							"raw": "//Deprecated as of v1.9.12.\n\n{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"ipcs.publishBlockchain\",\n    \"params\":{\n        \"blockchainID\":\"{{avalanceBlockchainId}}\"\n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -3387,13 +3307,13 @@
 					"response": []
 				},
 				{
-					"name": "unpublishBlockchain",
+					"name": "unpublishBlockchain - DEPRECATED",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"ipcs.unpublishBlockchain\",\n    \"params\":{\n        \"blockchainID\":\"{{avalanceBlockchainId}}\"\n    },\n    \"id\": 1\n}",
+							"raw": "//Deprecated as of v1.9.12.\n\n{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"ipcs.unpublishBlockchain\",\n    \"params\":{\n        \"blockchainID\":\"{{avalanceBlockchainId}}\"\n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -3421,13 +3341,13 @@
 			"name": "Keystore",
 			"item": [
 				{
-					"name": "createUser",
+					"name": "createUser - DEPRECATED",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"keystore.createUser\",\n    \"params\" :{\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    }\n}",
+							"raw": "//Deprecated as of v1.9.12.\n\n{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"keystore.createUser\",\n    \"params\" :{\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -3449,13 +3369,13 @@
 					"response": []
 				},
 				{
-					"name": "deleteUser",
+					"name": "deleteUser - DEPRECATED",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"keystore.deleteUser\",\n    \"params\" : {\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    }\n}",
+							"raw": "//Deprecated as of v1.9.12.\n\n{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"keystore.deleteUser\",\n    \"params\" : {\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -3477,13 +3397,13 @@
 					"response": []
 				},
 				{
-					"name": "exportUser",
+					"name": "exportUser  - DEPRECATED",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"id\": 1,\n    \"method\": \"keystore.exportUser\",\n    \"params\": {\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\",\n        \"encoding\": \"hex\"\n    }\n}",
+							"raw": "//Deprecated as of v1.9.12.\n\n{\n    \"jsonrpc\": \"2.0\",\n    \"id\": 1,\n    \"method\": \"keystore.exportUser\",\n    \"params\": {\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\",\n        \"encoding\": \"hex\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -3505,13 +3425,13 @@
 					"response": []
 				},
 				{
-					"name": "importUser",
+					"name": "importUser - DEPRECATED",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"keystore.importUser\",\n    \"params\" :{\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\",\n        \"user\"    :\"0x0000b79e54bb3452985874844fd02ce47671725850111b14d5b06d4b3e142ec852b39d1be2bdead684977bc0a1bfa6eeb06e000000040000004066687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f292500000000000000000000000000000000000000000000000000000000000000000000004c00000000002a92a15386259d71410fe602a9a1e2207a7afae3efd8d86f142577405476e5337a0736ba095b0fe911cb3100000018226dc5aec589008bc87ce142d5488d942f7e9d37374be99f0000003466687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f29253cb7d3842e8cee6a0ebd09f1fe884f6861e1b29c00000052000000000030b46ad90c1ef2f22282a9ab9c045cf190506148a7afcf4e94360e7e4109ef9abbc4aa97dd84533a5b081c0da489e205f00000001825e30947b222849b4f69b0a1eaf1dd49c82f5b64995d3c4e00000040faa57ee922f01eb75ca224d2e8aaf9cb60973d011e0ac08c7b3798c3aacf79de00000000000000000000000000000000000000000000000000000000000000000000004c00000000002a098545758bbf938acd508762ffff24bd2e8e0f80313fb0957c51fea30df6f304a94568c30dfb06257deb00000018e722d87e7d5964aa8a8772b0985d0723d398681ef29fad7900000034faa57ee922f01eb75ca224d2e8aaf9cb60973d011e0ac08c7b3798c3aacf79de3cb7d3842e8cee6a0ebd09f1fe884f6861e1b29c00000052000000000030722156f457680f16cf010d7cb3b350aaf210ae9ed58aaf89017f0046c5380ddf76fb944a6ff9a287a6a6e6c6303c751a000000183edfb66b8b01e6197507cde7e4909f816d3accf753155f96b346b48c\",\n        \"encoding\": \"hex\"\n    }\n}",
+							"raw": "//Deprecated as of v1.9.12.\n\n{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"keystore.importUser\",\n    \"params\" :{\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\",\n        \"user\"    :\"0x0000b79e54bb3452985874844fd02ce47671725850111b14d5b06d4b3e142ec852b39d1be2bdead684977bc0a1bfa6eeb06e000000040000004066687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f292500000000000000000000000000000000000000000000000000000000000000000000004c00000000002a92a15386259d71410fe602a9a1e2207a7afae3efd8d86f142577405476e5337a0736ba095b0fe911cb3100000018226dc5aec589008bc87ce142d5488d942f7e9d37374be99f0000003466687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f29253cb7d3842e8cee6a0ebd09f1fe884f6861e1b29c00000052000000000030b46ad90c1ef2f22282a9ab9c045cf190506148a7afcf4e94360e7e4109ef9abbc4aa97dd84533a5b081c0da489e205f00000001825e30947b222849b4f69b0a1eaf1dd49c82f5b64995d3c4e00000040faa57ee922f01eb75ca224d2e8aaf9cb60973d011e0ac08c7b3798c3aacf79de00000000000000000000000000000000000000000000000000000000000000000000004c00000000002a098545758bbf938acd508762ffff24bd2e8e0f80313fb0957c51fea30df6f304a94568c30dfb06257deb00000018e722d87e7d5964aa8a8772b0985d0723d398681ef29fad7900000034faa57ee922f01eb75ca224d2e8aaf9cb60973d011e0ac08c7b3798c3aacf79de3cb7d3842e8cee6a0ebd09f1fe884f6861e1b29c00000052000000000030722156f457680f16cf010d7cb3b350aaf210ae9ed58aaf89017f0046c5380ddf76fb944a6ff9a287a6a6e6c6303c751a000000183edfb66b8b01e6197507cde7e4909f816d3accf753155f96b346b48c\",\n        \"encoding\": \"hex\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -3533,13 +3453,13 @@
 					"response": []
 				},
 				{
-					"name": "listUsers",
+					"name": "listUsers - DEPRECATED",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"keystore.listUsers\"\n}",
+							"raw": "//Deprecated as of v1.9.12.\n\n{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"keystore.listUsers\"\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -3596,13 +3516,13 @@
 			"name": "PlatformVM",
 			"item": [
 				{
-					"name": "addDelegator",
+					"name": "addDelegator - DEPRECATED",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.addDelegator\",\n    \"params\": {\n        \"nodeId\":\"{{avalancheNodeId}}\",\n        \"startTime\":1613347036,\n        \"endTime\":1631215800,\n        \"stakeAmount\":200000000000,\n        \"rewardAddress\": \"{{pchainAddress}}\",\n        \"from\": [\"{{pchainAddress}}\"],\n        \"changeAddr\": \"{{pchainAddress}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
+							"raw": "//Deprecated as of v1.9.12.\n\n{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.addDelegator\",\n    \"params\": {\n        \"nodeId\":\"{{avalancheNodeId}}\",\n        \"startTime\":1613347036,\n        \"endTime\":1631215800,\n        \"stakeAmount\":200000000000,\n        \"rewardAddress\": \"{{pchainAddress}}\",\n        \"from\": [\"{{pchainAddress}}\"],\n        \"changeAddr\": \"{{pchainAddress}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -3625,13 +3545,13 @@
 					"response": []
 				},
 				{
-					"name": "addSubnetValidator",
+					"name": "addSubnetValidator - DEPRECATED",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.addSubnetValidator\",\n    \"params\": {\n        \"nodeID\":\"{{avalancheNodeId}}\",\n        \"subnetID\":\"{{avalancheSubnetId}}\",\n        \"startTime\":1625782598,\n        \"endTime\":1627078419,\n        \"weight\":20,\n        \"from\": [\"{{pchainAddress}}\"],\n        \"changeAddr\": \"{{pchainAddress}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
+							"raw": "//Deprecated as of v1.9.12.\n\n{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.addSubnetValidator\",\n    \"params\": {\n        \"nodeID\":\"{{avalancheNodeId}}\",\n        \"subnetID\":\"{{avalancheSubnetId}}\",\n        \"startTime\":1625782598,\n        \"endTime\":1627078419,\n        \"weight\":20,\n        \"from\": [\"{{pchainAddress}}\"],\n        \"changeAddr\": \"{{pchainAddress}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -3654,13 +3574,13 @@
 					"response": []
 				},
 				{
-					"name": "addValidator",
+					"name": "addValidator - DEPRECATED",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.addValidator\",\n    \"params\": {\n        \"nodeID\":\"{{avalancheNodeId}}\",\n        \"startTime\":1606245174,\n        \"endTime\":1608837056,\n        \"stakeAmount\":2000000000000,\n        \"rewardAddress\": \"{{pchainAddress}}\",\n        \"delegationFeeRate\":10,\n        \"from\": [\"{{pchainAddress}}\"],\n        \"changeAddr\": \"{{pchainAddress}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
+							"raw": "//Deprecated as of v1.9.12.\n\n{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.addValidator\",\n    \"params\": {\n        \"nodeID\":\"{{avalancheNodeId}}\",\n        \"startTime\":1606245174,\n        \"endTime\":1608837056,\n        \"stakeAmount\":2000000000000,\n        \"rewardAddress\": \"{{pchainAddress}}\",\n        \"delegationFeeRate\":10,\n        \"from\": [\"{{pchainAddress}}\"],\n        \"changeAddr\": \"{{pchainAddress}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -3683,13 +3603,13 @@
 					"response": []
 				},
 				{
-					"name": "createAddress",
+					"name": "createAddress - DEPRECATED",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.createAddress\",\n    \"params\": {\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
+							"raw": "//Deprecated as of v1.9.12.\n\n{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.createAddress\",\n    \"params\": {\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -3712,13 +3632,13 @@
 					"response": []
 				},
 				{
-					"name": "createBlockchain",
+					"name": "createBlockchain - DEPRECATED",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.createBlockchain\",\n    \"params\" : {\n        \"vmID\":\"avm\",\n        \"SubnetID\":\"{{avalancheSubnetId}}\",\n        \"name\":\"My new avm\",\n        \"genesisData\": \"111115LHK2ZCYttSKPmmhsTDSuKiCkmHz65nUS1YqybvjirwGLLt376k1RwnTt72WobPqrG7rmgrKVqSq6VxDsKXYGnRmfhdLCEhsYjM\",\n        \"encoding\": \"hex\",\n        \"from\": [\"{{pchainAddress}}\"],\n        \"changeAddr\": \"{{pchainAddress}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
+							"raw": "//Deprecated as of v1.9.12.\n\n{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.createBlockchain\",\n    \"params\" : {\n        \"vmID\":\"avm\",\n        \"SubnetID\":\"{{avalancheSubnetId}}\",\n        \"name\":\"My new avm\",\n        \"genesisData\": \"111115LHK2ZCYttSKPmmhsTDSuKiCkmHz65nUS1YqybvjirwGLLt376k1RwnTt72WobPqrG7rmgrKVqSq6VxDsKXYGnRmfhdLCEhsYjM\",\n        \"encoding\": \"hex\",\n        \"from\": [\"{{pchainAddress}}\"],\n        \"changeAddr\": \"{{pchainAddress}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -3741,13 +3661,13 @@
 					"response": []
 				},
 				{
-					"name": "createSubnet",
+					"name": "createSubnet - DEPRECATED",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.createSubnet\",\n    \"params\": {\n        \"controlKeys\":[\n            \"{{pchainAddress}}\"\n        ],\n        \"threshold\":1,\n        \"from\": [\"{{pchainAddress}}\"],\n        \"changeAddr\":\"{{pchainAddress}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
+							"raw": "//Deprecated as of v1.9.12.\n\n{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.createSubnet\",\n    \"params\": {\n        \"controlKeys\":[\n            \"{{pchainAddress}}\"\n        ],\n        \"threshold\":1,\n        \"from\": [\"{{pchainAddress}}\"],\n        \"changeAddr\":\"{{pchainAddress}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -3770,13 +3690,13 @@
 					"response": []
 				},
 				{
-					"name": "exportAVAX",
+					"name": "exportAVAX - DEPRECATED",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.exportAVAX\",\n    \"params\": {\n        \"to\":\"{{xchainAddress}}\",\n        \"amount\":54321,\n        \"from\": [\"{{pchainAddress}}\"],\n        \"changeAddr\": \"{{pchainAddress}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
+							"raw": "//Deprecated as of v1.9.12.\n\n{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.exportAVAX\",\n    \"params\": {\n        \"to\":\"{{xchainAddress}}\",\n        \"amount\":54321,\n        \"from\": [\"{{pchainAddress}}\"],\n        \"changeAddr\": \"{{pchainAddress}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -3799,13 +3719,13 @@
 					"response": []
 				},
 				{
-					"name": "exportKey",
+					"name": "exportKey - DEPRECATED",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.exportKey\",\n    \"params\" :{\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\",\n        \"address\": \"{{pchainAddress}}\"\n    }\n}",
+							"raw": "//Deprecated as of v1.9.12.\n\n{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.exportKey\",\n    \"params\" :{\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\",\n        \"address\": \"{{pchainAddress}}\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -3828,13 +3748,13 @@
 					"response": []
 				},
 				{
-					"name": "getBalance",
+					"name": "getBalance - DEPRECATED",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getBalance\",\n    \"params\" :{\n      \"addresses\":[\"{{pchainAddress}}\"]    \n    }\n}",
+							"raw": "//Deprecated as of v1.9.12.\n\n{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getBalance\",\n    \"params\" :{\n      \"addresses\":[\"{{pchainAddress}}\"]    \n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -3886,13 +3806,13 @@
 					"response": []
 				},
 				{
-					"name": "getBlockchains",
+					"name": "getBlockchains - DEPRECATED",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.getBlockchains\",\n    \"params\": {},\n    \"id\": 1\n}",
+							"raw": "//Deprecated as of v1.9.12.\n\n{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.getBlockchains\",\n    \"params\": {},\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -4031,13 +3951,13 @@
 					"response": []
 				},
 				{
-					"name": "getMaxStakeAmount",
+					"name": "getMaxStakeAmount - DEPRECATED",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.getMaxStakeAmount\",\n    \"params\": {\n        \"subnetID\":\"\",\n        \"nodeID\":\"\",\n        \"startTime\": 123,\n        \"endTime\": 321\n    },\n    \"id\": 1\n}",
+							"raw": "//Deprecated as of v1.9.12.\n\n{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.getMaxStakeAmount\",\n    \"params\": {\n        \"subnetID\":\"\",\n        \"nodeID\":\"\",\n        \"startTime\": 123,\n        \"endTime\": 321\n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -4118,13 +4038,13 @@
 					"response": []
 				},
 				{
-					"name": "getRewardUTXOs",
+					"name": "getRewardUTXOs - DEPRECATED",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getRewardUTXOs\",\n    \"params\" :{\n        \"txID\":\"2nmH8LithVbdjaXsxVQCQfXtzN9hBbmebrsaEYnLM9T32Uy2Y4\",\n        \"encoding\": \"hex\"\n    }\n}",
+							"raw": "//Deprecated as of v1.9.12.\n\n{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getRewardUTXOs\",\n    \"params\" :{\n        \"txID\":\"2nmH8LithVbdjaXsxVQCQfXtzN9hBbmebrsaEYnLM9T32Uy2Y4\",\n        \"encoding\": \"hex\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -4147,13 +4067,13 @@
 					"response": []
 				},
 				{
-					"name": "getStake",
+					"name": "getStake - DEPRECATED",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getStake\",\n    \"params\": {\n        \"addresses\": [\"{{pchainAddress}}\"],\n        \"encoding\": \"hex\"\n    }\n}",
+							"raw": "//Deprecated as of v1.9.12.\n\n{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getStake\",\n    \"params\": {\n        \"addresses\": [\"{{pchainAddress}}\"],\n        \"encoding\": \"hex\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -4205,13 +4125,13 @@
 					"response": []
 				},
 				{
-					"name": "getSubnets",
+					"name": "getSubnets - DEPRECATED",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.getSubnets\",\n    \"params\": {\n        \"ids\": [\"{{avalancheSubnetId}}\"]\n    },\n    \"id\": 1\n}",
+							"raw": "//Deprecated as of v1.9.12.\n\n{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.getSubnets\",\n    \"params\": {\n        \"ids\": [\"{{avalancheSubnetId}}\"]\n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -4408,13 +4328,13 @@
 					"response": []
 				},
 				{
-					"name": "importAVAX",
+					"name": "importAVAX - DEPRECATED",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.importAVAX\",\n    \"params\": {\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"sourceChain\": \"X\",\n        \"to\":\"{{pchainAddress}}\",\n        \"from\": [\"{{pchainAddress}}\"],\n        \"changeAddr\": \"{{pchainAddress}}\"\n    },\n    \"id\": 1\n}",
+							"raw": "//Deprecated as of v1.9.12.\n\n{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.importAVAX\",\n    \"params\": {\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"sourceChain\": \"X\",\n        \"to\":\"{{pchainAddress}}\",\n        \"from\": [\"{{pchainAddress}}\"],\n        \"changeAddr\": \"{{pchainAddress}}\"\n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -4437,13 +4357,13 @@
 					"response": []
 				},
 				{
-					"name": "importKey",
+					"name": "importKey - DEPRECATED",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.importKey\",\n    \"params\" :{\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"privateKey\":\"{{privkey}}\"\n    }\n}",
+							"raw": "//Deprecated as of v1.9.12.\n\n{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.importKey\",\n    \"params\" :{\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"privateKey\":\"{{privkey}}\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -4495,13 +4415,13 @@
 					"response": []
 				},
 				{
-					"name": "listAddresses",
+					"name": "listAddresses - DEPRECATED",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.listAddresses\",\n    \"params\": {\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
+							"raw": "//Deprecated as of v1.9.12.\n\n\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.listAddresses\",\n    \"params\": {\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"

--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -384,6 +384,36 @@
 					"response": []
 				},
 				{
+					"name": "createMintTx",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.mint\",\n    \"params\" :{\n        \"amount\": 10000000,\n        \"assetID\": \"2qnR9pLQTDZ9boSbcrcjS4n1DJJkzbkNsJzgwYvmRy8uv47fZT\",\n        \"from\": [\"{{xchainAddress}}\"],\n        \"to\": \"{{xchainAddress}}\",\n        \"minters\": [\n            \"{{xchainAddress}}\"\n        ],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\" \n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{http}}://{{host}}:{{port}}/ext/X",
+							"protocol": "{{http}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"X"
+							]
+						},
+						"description": "Create an unsigned transaction to mint more of a variable-cap asset (an asset created with `avm.createVariableCapAsset`.) [More info](https://docs.avax.network/v1.0/en/api/avm/#avmcreateminttx)"
+					},
+					"response": []
+				},
+				{
 					"name": "createNFTAsset",
 					"request": {
 						"method": "POST",
@@ -837,36 +867,6 @@
 					"response": []
 				},
 				{
-					"name": "mint",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.mint\",\n    \"params\" :{\n        \"amount\": 10000000,\n        \"assetID\": \"2qnR9pLQTDZ9boSbcrcjS4n1DJJkzbkNsJzgwYvmRy8uv47fZT\",\n        \"from\": [\"{{xchainAddress}}\"],\n        \"to\": \"{{xchainAddress}}\",\n        \"minters\": [\n            \"{{xchainAddress}}\"\n        ],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\" \n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/X",
-							"protocol": "{{http}}",
-							"host": [
-								"{{host}}"
-							],
-							"port": "{{port}}",
-							"path": [
-								"ext",
-								"X"
-							]
-						},
-						"description": "Create an unsigned transaction to mint more of a variable-cap asset (an asset created with `avm.createVariableCapAsset`.) [More info](https://docs.avax.network/v1.0/en/api/avm/#avmcreateminttx)"
-					},
-					"response": []
-				},
-				{
 					"name": "mintNFT",
 					"request": {
 						"method": "POST",
@@ -1188,68 +1188,6 @@
 					"response": []
 				},
 				{
-					"name": "export",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"avax.export\",\n    \"params\": {\n        \"to\":\"{{xchainAddress}}\",\n        \"amount\": 5,\n        \"assetID\": \"2WGXKuZoHNjoHxMUhSvT1iFnps3tGGGpfJFDKN3Lyt5QmUhBBL\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/avax",
-							"protocol": "{{http}}",
-							"host": [
-								"{{host}}"
-							],
-							"port": "{{port}}",
-							"path": [
-								"ext",
-								"bc",
-								"C",
-								"avax"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "exportAVAX",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"avax.exportAVAX\",\n    \"params\": {\n        \"to\":\"{{xchainAddress}}\",\n        \"amount\": 99000000,\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/avax",
-							"protocol": "{{http}}",
-							"host": [
-								"{{host}}"
-							],
-							"port": "{{port}}",
-							"path": [
-								"ext",
-								"bc",
-								"C",
-								"avax"
-							]
-						}
-					},
-					"response": []
-				},
-				{
 					"name": "exportKey",
 					"request": {
 						"method": "POST",
@@ -1257,68 +1195,6 @@
 						"body": {
 							"mode": "raw",
 							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"avax.exportKey\",\n    \"params\": {\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"address\":\"{{cchainAddress}}\"\n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/avax",
-							"protocol": "{{http}}",
-							"host": [
-								"{{host}}"
-							],
-							"port": "{{port}}",
-							"path": [
-								"ext",
-								"bc",
-								"C",
-								"avax"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "import",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"avax.import\",\n    \"params\": {\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"assetID\": \"2nzgmhZLuVq8jc7NNu2eahkKwoJcbFWXWJCxHBVWAJEZkhquoK\",\n        \"sourceChain\": \"X\",\n        \"to\":\"{{cchainAddress}}\"\n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/avax",
-							"protocol": "{{http}}",
-							"host": [
-								"{{host}}"
-							],
-							"port": "{{port}}",
-							"path": [
-								"ext",
-								"bc",
-								"C",
-								"avax"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "importAVAX",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"avax.importAVAX\",\n    \"params\": {\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"sourceChain\": \"X\",\n        \"to\":\"{{cchainAddress}}\"\n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"

--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "e935c935-aad0-4d36-99ea-db1283e94515",
+		"_postman_id": "3b7439ce-aea0-4e37-8d28-361ac42bcb40",
 		"name": "Avalanche",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -472,7 +472,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "cf50830d-fafc-4a6d-b0d7-2f596b44ae1b",
+								"id": "46707d03-a0fe-4aa1-83ec-5f6efbf3a1c4",
 								"exec": [
 									"var template = `",
 									"    <table bgcolor=\"#FFFFFF\">",
@@ -1666,6 +1666,39 @@
 						"description": "Get description of peer connections. [More info](https://docs.avax.network/v1.0/en/api/info/#infopeers)"
 					},
 					"response": []
+				},
+				{
+					"name": "isBootstrapped",
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {}
+					},
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"jsonrpc\":\"2.0\",\r\n    \"id\"     :1,\r\n    \"method\" :\"info.isBootstrapped\",\r\n    \"params\": {\r\n        \"chain\":\"X\"\r\n    }\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{http}}://{{host}}:{{port}}/ext/info",
+							"protocol": "{{http}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"info"
+							]
+						},
+						"description": "Checks whether the chain is done boostrapping. Use \"chain\" parameter to select which chain to query, can be one of \"X\", \"P\" or \"C\"."
+					},
+					"response": []
 				}
 			],
 			"description": "This API can be used to access basic information about the node.",
@@ -2368,7 +2401,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/P",
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
 							"protocol": "{{http}}",
 							"host": [
 								"{{host}}"

--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -919,7 +919,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.send\",\n    \"params\" :{ \n        \"assetID\" : \"{{avaxAssetId}}\",\n        \"amount\"  : 2000000,\n        \"from\"    : [\"{{xchainAddress}}\"],\n        \"to\"      : \"X-avax1g8u6w6jnnwd8p280q38wwrwkr357pzq3asspdz\",\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"memo\"    : \"{{memo}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\" \n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.send\",\n    \"params\" :{ \n        \"assetID\" : \"{{avaxAssetId}}\",\n        \"amount\"  : 2000000,\n        \"from\"    : [\"{{xchainAddress}}\"],\n        \"to\"      : \"{{xchainAddress}}\",\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"memo\"    : \"{{memo}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\" \n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"

--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -3295,6 +3295,36 @@
 					"response": []
 				},
 				{
+					"name": "uptime",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"info.uptime\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/info",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"info"
+							]
+						},
+						"description": "Returns the network's observed uptime of this node. [More info](https://docs.avax.network/build/avalanchego-apis/info-api#info-uptime)"
+					},
+					"response": []
+				},
+				{
 					"name": "peers",
 					"request": {
 						"method": "POST",

--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -1188,68 +1188,6 @@
 					"response": []
 				},
 				{
-					"name": "exportKey",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"avax.exportKey\",\n    \"params\": {\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"address\":\"{{cchainAddress}}\"\n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/avax",
-							"protocol": "{{http}}",
-							"host": [
-								"{{host}}"
-							],
-							"port": "{{port}}",
-							"path": [
-								"ext",
-								"bc",
-								"C",
-								"avax"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "importKey",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"avax.importKey\",\n    \"params\": {\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"privateKey\":\"{{privkey}}\"\n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/avax",
-							"protocol": "{{http}}",
-							"host": [
-								"{{host}}"
-							],
-							"port": "{{port}}",
-							"path": [
-								"ext",
-								"bc",
-								"C",
-								"avax"
-							]
-						}
-					},
-					"response": []
-				},
-				{
 					"name": "personal_newAccount",
 					"request": {
 						"method": "POST",

--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -1,7 +1,7 @@
 {
 	"info": {
 		"_postman_id": "984c5ef8-73b4-4a76-b864-2581bd34f195",
-		"name": "Avalanche Copy 2",
+		"name": "Avalanche",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "23086587"
 	},

--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "1ee7a070-3262-42d5-9cb2-3ec00a0a5d5e",
-		"name": "Avalanche",
+		"_postman_id": "984c5ef8-73b4-4a76-b864-2581bd34f195",
+		"name": "Avalanche Copy 2",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "12086068"
+		"_exporter_id": "23086587"
 	},
 	"item": [
 		{
@@ -761,6 +761,186 @@
 							]
 						},
 						"description": "Get the balance of an asset controlled by a given address. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-getbalance)"
+					},
+					"response": []
+				},
+				{
+					"name": "getBlock",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var template = `",
+									"    <table bgcolor=\"#FFFFFF\">",
+									"        <tr>",
+									"            <th>Name</th>",
+									"            <th>Email</th>",
+									"        </tr>",
+									"",
+									"        {{#each response}}",
+									"            <tr>",
+									"                <td>{{name}}</td>",
+									"                <td>{{email}}</td>",
+									"            </tr>",
+									"        {{/each}}",
+									"    </table>",
+									"`;",
+									"",
+									"// Set visualizer",
+									"pm.visualizer.set(template, {",
+									"    // Pass the response body parsed as JSON as `data`",
+									"    response: pm.response.json()",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.getBlock\",\n    \"params\" :{\n        \"blockID\": \"{{xchainBlockID}}\",\n        \"encoding\": \"hex\"\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseURL}}/ext/bc/X",
+							"host": [
+								"{{baseURL}}"
+							],
+							"path": [
+								"ext",
+								"bc",
+								"X"
+							]
+						},
+						"description": "Returns the block with the given id. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-getbalance)"
+					},
+					"response": []
+				},
+				{
+					"name": "getBlockByHeight",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var template = `",
+									"    <table bgcolor=\"#FFFFFF\">",
+									"        <tr>",
+									"            <th>Name</th>",
+									"            <th>Email</th>",
+									"        </tr>",
+									"",
+									"        {{#each response}}",
+									"            <tr>",
+									"                <td>{{name}}</td>",
+									"                <td>{{email}}</td>",
+									"            </tr>",
+									"        {{/each}}",
+									"    </table>",
+									"`;",
+									"",
+									"// Set visualizer",
+									"pm.visualizer.set(template, {",
+									"    // Pass the response body parsed as JSON as `data`",
+									"    response: pm.response.json()",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.getBlockByHeight\",\n    \"params\" :{\n        \"height\": {{height}},\n        \"encoding\": \"hex\"\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseURL}}/ext/bc/X",
+							"host": [
+								"{{baseURL}}"
+							],
+							"path": [
+								"ext",
+								"bc",
+								"X"
+							]
+						},
+						"description": "Returns block at the given height. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-getbalance)"
+					},
+					"response": []
+				},
+				{
+					"name": "getHeight",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var template = `",
+									"    <table bgcolor=\"#FFFFFF\">",
+									"        <tr>",
+									"            <th>Name</th>",
+									"            <th>Email</th>",
+									"        </tr>",
+									"",
+									"        {{#each response}}",
+									"            <tr>",
+									"                <td>{{name}}</td>",
+									"                <td>{{email}}</td>",
+									"            </tr>",
+									"        {{/each}}",
+									"    </table>",
+									"`;",
+									"",
+									"// Set visualizer",
+									"pm.visualizer.set(template, {",
+									"    // Pass the response body parsed as JSON as `data`",
+									"    response: pm.response.json()",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.getHeight\",\n    \"params\" :{}\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseURL}}/ext/bc/X",
+							"host": [
+								"{{baseURL}}"
+							],
+							"path": [
+								"ext",
+								"bc",
+								"X"
+							]
+						},
+						"description": "Returns the height of the last accepted block. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-getbalance)"
 					},
 					"response": []
 				},

--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "007a173c-071b-4df4-8914-368bfacf1d3f",
+		"_postman_id": "e2bf7d02-bde8-4c54-af75-b15ad7922a01",
 		"name": "Avalanche",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -23,8 +23,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/admin",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/admin",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -53,8 +53,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/admin",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/admin",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -83,8 +83,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/admin",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/admin",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -113,8 +113,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/admin",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/admin",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -143,8 +143,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/admin",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/admin",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -173,8 +173,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/admin",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/admin",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -203,8 +203,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/admin",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/admin",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -239,8 +239,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/auth",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/auth",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -269,8 +269,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/auth",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/auth",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -299,8 +299,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/auth",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/auth",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -335,8 +335,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/vm/avm",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/vm/avm",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -366,8 +366,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/X",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/X",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -397,8 +397,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/X",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/X",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -428,8 +428,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/X",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/X",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -459,8 +459,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/X",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/X",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -490,8 +490,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/X",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/X",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -521,8 +521,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/X",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/X",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -552,8 +552,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/X",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/X",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -583,8 +583,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/X",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/X",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -614,8 +614,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/X",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/X",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -645,8 +645,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/X",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/X",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -707,8 +707,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/X",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/X",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -738,8 +738,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/X",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/X",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -769,8 +769,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/X",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/X",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -800,8 +800,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/X",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/X",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -831,8 +831,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/X",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/X",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -862,8 +862,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/X",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/X",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -893,8 +893,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/X",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/X",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -924,8 +924,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/X",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/X",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -955,8 +955,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/X",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/X",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -986,8 +986,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/X",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/X",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -1017,8 +1017,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/X",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/X",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -1048,8 +1048,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/X",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/X",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -1079,8 +1079,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/X",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/X",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -1110,8 +1110,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/X",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/X",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -1141,8 +1141,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/X",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/X",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -1172,8 +1172,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/X",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/X",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -1209,8 +1209,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/rpc",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/rpc",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -1241,8 +1241,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/rpc",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/rpc",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -1273,8 +1273,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/rpc",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/rpc",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -1305,8 +1305,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/rpc",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/rpc",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -1337,8 +1337,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/rpc",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/rpc",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -1369,8 +1369,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/rpc",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/rpc",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -1401,8 +1401,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/rpc",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/rpc",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -1433,8 +1433,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/rpc",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/rpc",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -1465,8 +1465,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/rpc",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/rpc",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -1497,8 +1497,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/rpc",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/rpc",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -1529,8 +1529,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/rpc",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/rpc",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -1561,8 +1561,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/rpc",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/rpc",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -1593,8 +1593,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/avax",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/avax",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -1625,8 +1625,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/avax",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/avax",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -1657,8 +1657,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/avax",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/avax",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -1689,8 +1689,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/avax",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/avax",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -1721,8 +1721,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/avax",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/avax",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -1753,8 +1753,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/avax",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/avax",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -1785,8 +1785,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/avax",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/avax",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -1817,8 +1817,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/avax",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/avax",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -1849,8 +1849,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/avax",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/avax",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -1881,8 +1881,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/avax",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/avax",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -1913,8 +1913,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/rpc",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/rpc",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -1945,8 +1945,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/rpc",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/rpc",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -1977,8 +1977,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/rpc",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/rpc",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -2009,8 +2009,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/rpc",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/rpc",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -2041,8 +2041,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/rpc",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/rpc",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -2073,8 +2073,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/rpc",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/rpc",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -2105,8 +2105,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/rpc",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/rpc",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -2137,8 +2137,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/rpc",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/rpc",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -2175,8 +2175,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/health",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/health",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -2214,8 +2214,8 @@
 									}
 								},
 								"url": {
-									"raw": "{{http}}://{{host}}:{{port}}/ext/index/X/tx",
-									"protocol": "{{http}}",
+									"raw": "{{protocol}}://{{host}}:{{port}}/ext/index/X/tx",
+									"protocol": "{{protocol}}",
 									"host": [
 										"{{host}}"
 									],
@@ -2246,8 +2246,8 @@
 									}
 								},
 								"url": {
-									"raw": "{{http}}://{{host}}:{{port}}/ext/index/X/tx",
-									"protocol": "{{http}}",
+									"raw": "{{protocol}}://{{host}}:{{port}}/ext/index/X/tx",
+									"protocol": "{{protocol}}",
 									"host": [
 										"{{host}}"
 									],
@@ -2278,8 +2278,8 @@
 									}
 								},
 								"url": {
-									"raw": "{{http}}://{{host}}:{{port}}/ext/index/X/tx",
-									"protocol": "{{http}}",
+									"raw": "{{protocol}}://{{host}}:{{port}}/ext/index/X/tx",
+									"protocol": "{{protocol}}",
 									"host": [
 										"{{host}}"
 									],
@@ -2310,8 +2310,8 @@
 									}
 								},
 								"url": {
-									"raw": "{{http}}://{{host}}:{{port}}/ext/index/X/tx",
-									"protocol": "{{http}}",
+									"raw": "{{protocol}}://{{host}}:{{port}}/ext/index/X/tx",
+									"protocol": "{{protocol}}",
 									"host": [
 										"{{host}}"
 									],
@@ -2342,8 +2342,8 @@
 									}
 								},
 								"url": {
-									"raw": "{{http}}://{{host}}:{{port}}/ext/index/X/tx",
-									"protocol": "{{http}}",
+									"raw": "{{protocol}}://{{host}}:{{port}}/ext/index/X/tx",
+									"protocol": "{{protocol}}",
 									"host": [
 										"{{host}}"
 									],
@@ -2379,8 +2379,8 @@
 									}
 								},
 								"url": {
-									"raw": "{{http}}://{{host}}:{{port}}/ext/index/X/vtx",
-									"protocol": "{{http}}",
+									"raw": "{{protocol}}://{{host}}:{{port}}/ext/index/X/vtx",
+									"protocol": "{{protocol}}",
 									"host": [
 										"{{host}}"
 									],
@@ -2411,8 +2411,8 @@
 									}
 								},
 								"url": {
-									"raw": "{{http}}://{{host}}:{{port}}/ext/index/X/vtx",
-									"protocol": "{{http}}",
+									"raw": "{{protocol}}://{{host}}:{{port}}/ext/index/X/vtx",
+									"protocol": "{{protocol}}",
 									"host": [
 										"{{host}}"
 									],
@@ -2443,8 +2443,8 @@
 									}
 								},
 								"url": {
-									"raw": "{{http}}://{{host}}:{{port}}/ext/index/X/vtx",
-									"protocol": "{{http}}",
+									"raw": "{{protocol}}://{{host}}:{{port}}/ext/index/X/vtx",
+									"protocol": "{{protocol}}",
 									"host": [
 										"{{host}}"
 									],
@@ -2475,8 +2475,8 @@
 									}
 								},
 								"url": {
-									"raw": "{{http}}://{{host}}:{{port}}/ext/index/X/vtx",
-									"protocol": "{{http}}",
+									"raw": "{{protocol}}://{{host}}:{{port}}/ext/index/X/vtx",
+									"protocol": "{{protocol}}",
 									"host": [
 										"{{host}}"
 									],
@@ -2507,8 +2507,8 @@
 									}
 								},
 								"url": {
-									"raw": "{{http}}://{{host}}:{{port}}/ext/index/X/vtx",
-									"protocol": "{{http}}",
+									"raw": "{{protocol}}://{{host}}:{{port}}/ext/index/X/vtx",
+									"protocol": "{{protocol}}",
 									"host": [
 										"{{host}}"
 									],
@@ -2544,8 +2544,8 @@
 									}
 								},
 								"url": {
-									"raw": "{{http}}://{{host}}:{{port}}/ext/index/P/block",
-									"protocol": "{{http}}",
+									"raw": "{{protocol}}://{{host}}:{{port}}/ext/index/P/block",
+									"protocol": "{{protocol}}",
 									"host": [
 										"{{host}}"
 									],
@@ -2576,8 +2576,8 @@
 									}
 								},
 								"url": {
-									"raw": "{{http}}://{{host}}:{{port}}/ext/index/P/block",
-									"protocol": "{{http}}",
+									"raw": "{{protocol}}://{{host}}:{{port}}/ext/index/P/block",
+									"protocol": "{{protocol}}",
 									"host": [
 										"{{host}}"
 									],
@@ -2608,8 +2608,8 @@
 									}
 								},
 								"url": {
-									"raw": "{{http}}://{{host}}:{{port}}/ext/index/P/block",
-									"protocol": "{{http}}",
+									"raw": "{{protocol}}://{{host}}:{{port}}/ext/index/P/block",
+									"protocol": "{{protocol}}",
 									"host": [
 										"{{host}}"
 									],
@@ -2640,8 +2640,8 @@
 									}
 								},
 								"url": {
-									"raw": "{{http}}://{{host}}:{{port}}/ext/index/P/block",
-									"protocol": "{{http}}",
+									"raw": "{{protocol}}://{{host}}:{{port}}/ext/index/P/block",
+									"protocol": "{{protocol}}",
 									"host": [
 										"{{host}}"
 									],
@@ -2672,8 +2672,8 @@
 									}
 								},
 								"url": {
-									"raw": "{{http}}://{{host}}:{{port}}/ext/index/P/block",
-									"protocol": "{{http}}",
+									"raw": "{{protocol}}://{{host}}:{{port}}/ext/index/P/block",
+									"protocol": "{{protocol}}",
 									"host": [
 										"{{host}}"
 									],
@@ -2709,8 +2709,8 @@
 									}
 								},
 								"url": {
-									"raw": "{{http}}://{{host}}:{{port}}/ext/index/C/block",
-									"protocol": "{{http}}",
+									"raw": "{{protocol}}://{{host}}:{{port}}/ext/index/C/block",
+									"protocol": "{{protocol}}",
 									"host": [
 										"{{host}}"
 									],
@@ -2741,8 +2741,8 @@
 									}
 								},
 								"url": {
-									"raw": "{{http}}://{{host}}:{{port}}/ext/index/C/block",
-									"protocol": "{{http}}",
+									"raw": "{{protocol}}://{{host}}:{{port}}/ext/index/C/block",
+									"protocol": "{{protocol}}",
 									"host": [
 										"{{host}}"
 									],
@@ -2773,8 +2773,8 @@
 									}
 								},
 								"url": {
-									"raw": "{{http}}://{{host}}:{{port}}/ext/index/C/block",
-									"protocol": "{{http}}",
+									"raw": "{{protocol}}://{{host}}:{{port}}/ext/index/C/block",
+									"protocol": "{{protocol}}",
 									"host": [
 										"{{host}}"
 									],
@@ -2805,8 +2805,8 @@
 									}
 								},
 								"url": {
-									"raw": "{{http}}://{{host}}:{{port}}/ext/index/C/block",
-									"protocol": "{{http}}",
+									"raw": "{{protocol}}://{{host}}:{{port}}/ext/index/C/block",
+									"protocol": "{{protocol}}",
 									"host": [
 										"{{host}}"
 									],
@@ -2837,8 +2837,8 @@
 									}
 								},
 								"url": {
-									"raw": "{{http}}://{{host}}:{{port}}/ext/index/C/block",
-									"protocol": "{{http}}",
+									"raw": "{{protocol}}://{{host}}:{{port}}/ext/index/C/block",
+									"protocol": "{{protocol}}",
 									"host": [
 										"{{host}}"
 									],
@@ -2877,8 +2877,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/info",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/info",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -2907,8 +2907,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/info",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/info",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -2937,8 +2937,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/info",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/info",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -2967,8 +2967,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/info",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/info",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -2997,8 +2997,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/info",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/info",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -3027,8 +3027,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/info",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/info",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -3057,8 +3057,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/info",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/info",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -3087,8 +3087,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/info",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/info",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -3117,8 +3117,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/info",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/info",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -3153,8 +3153,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/ipcs",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/ipcs",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -3183,8 +3183,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/ipcs",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/ipcs",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -3219,8 +3219,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/keystore",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/keystore",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -3249,8 +3249,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/keystore",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/keystore",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -3279,8 +3279,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/keystore",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/keystore",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -3309,8 +3309,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/keystore",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/keystore",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -3339,8 +3339,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/keystore",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/keystore",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -3370,8 +3370,8 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/metrics",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/metrics",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -3406,8 +3406,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -3437,8 +3437,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -3468,8 +3468,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -3499,8 +3499,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -3530,8 +3530,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -3561,8 +3561,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -3592,8 +3592,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -3623,8 +3623,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -3654,8 +3654,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -3685,8 +3685,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -3716,8 +3716,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -3747,8 +3747,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -3778,8 +3778,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -3809,8 +3809,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -3840,8 +3840,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -3871,8 +3871,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -3902,8 +3902,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -3933,8 +3933,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -3964,8 +3964,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -3995,8 +3995,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -4026,8 +4026,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -4057,8 +4057,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -4088,8 +4088,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -4119,8 +4119,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -4150,8 +4150,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -4181,8 +4181,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -4212,8 +4212,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -4243,8 +4243,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -4274,8 +4274,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],
@@ -4305,8 +4305,8 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
-							"protocol": "{{http}}",
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
+							"protocol": "{{protocol}}",
 							"host": [
 								"{{host}}"
 							],

--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -454,7 +454,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.export\",\n    \"params\" :{\n        \"from\": [\"{{xchainAddress}}\"],\n        \"to\":\"{{cchainbech32address}}\",\n        \"amount\": 50,\n        \"assetID\": \"2YmsQfMaCczE4mLG1DPYUnRURNGfhjj4qrqnLRR3LmZ3GxDWPt\",\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.export\",\n    \"params\" :{\n        \"from\": [\"{{xchainAddress}}\"],\n        \"to\":\"{{cchainbech32address}}\",\n        \"amount\": 4000001000000         ,\n        \"assetID\": \"AVAX\",\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1465,7 +1465,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"method\" :\"avax.export\",\n    \"params\" :{\n        \"from\": [\"{{cchainAddress}}\"],\n        \"to\":\"{{xchainAddress}}\",\n        \"amount\": 25,\n        \"destinationChain\": \"X\",\n        \"changeAddr\": \"{{cchainAddress}}\",\n        \"assetID\": \"2W4XDTMrQJm7YALcnCL4krU7JpoGQQaDkTdn2HbzpsqombHRaB\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\"\n    },\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1\n}",
+							"raw": "{\n    \"method\" :\"avax.export\",\n    \"params\" :{\n        \"from\": [\"{{cchainAddress}}\"],\n        \"to\":\"{{xchainAddress}}\",\n        \"amount\": 25,\n        \"changeAddr\": \"{{cchainAddress}}\",\n        \"assetID\": \"FSznYPiqrJ3WtGurw54re47oDpGXQ8THc8yZ4fEDX4G8cGqbn\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\"\n    },\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1497,7 +1497,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"method\" :\"avax.exportAVAX\",\n    \"params\" :{\n        \"from\": [\"{{cchainAddress}}\"],\n        \"to\":\"{{xchainAddress}}\",\n        \"amount\": 4000001000000,\n        \"destinationChain\": \"X\",\n        \"changeAddr\": \"{{cchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    },\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1\n}",
+							"raw": "{\n    \"method\" :\"avax.exportAVAX\",\n    \"params\" :{\n        \"from\": [\"{{cchainAddress}}\"],\n        \"to\":\"{{xchainAddress}}\",\n        \"amount\": 999000000,\n        \"destinationChain\": \"X\",\n        \"changeAddr\": \"{{cchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    },\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -2652,7 +2652,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.addValidator\",\n    \"params\": {\n        \"nodeID\":\"{{avalancheNodeId}}\",\n        \"startTime\":1598664856,\n        \"endTime\":1601256253,\n        \"stakeAmount\":200000000000,\n        \"rewardAddress\": \"{{pchainAddress}}\",\n        \"delegationFeeRate\":10,\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.addValidator\",\n    \"params\": {\n        \"nodeID\":\"{{avalancheNodeId}}\",\n        \"startTime\":1606245174,\n        \"endTime\":1608837056,\n        \"stakeAmount\":2000000000000,\n        \"rewardAddress\": \"{{pchainAddress}}\",\n        \"delegationFeeRate\":10,\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -2776,7 +2776,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.createSubnet\",\n    \"params\": {\n        \"controlKeys\":[\n            \"{{pchainAddress}}\"\n        ],\n        \"threshold\":1,\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.createSubnet\",\n    \"params\": {\n        \"controlKeys\":[\n            \"{{pchainAddress}}\"\n        ],\n        \"threshold\":1,\n        \"from\": [{{pchainAddress}}]\n        \"changeAddr\":\"{{pchainAddress}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"

--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -193,6 +193,103 @@
 			"protocolProfileBehavior": {}
 		},
 		{
+			"name": "Auth",
+			"item": [
+				{
+					"name": "newToken",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"auth.newToken\",\n    \"params\": {\n        \"password\":\"YOUR PASSWORD GOES HERE\",\n        \"endpoints\":[\"/ext/bc/X\", \"/ext/info\"]\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{http}}://{{host}}:{{port}}/ext/auth",
+							"protocol": "{{http}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"auth"
+							]
+						},
+						"description": "Creates a new authorization token that grants access to one or more API endpoints.\n (https://docs.avax.network/v1.0/en/api/auth/#authnewtoken)"
+					},
+					"response": []
+				},
+				{
+					"name": "revokeToken",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"auth.revokeToken\",\n    \"params\": {\n        \"password\":\"password goes here\",\n        \"token\":\"token goes here\"\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{http}}://{{host}}:{{port}}/ext/auth",
+							"protocol": "{{http}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"auth"
+							]
+						},
+						"description": "Revoke a previously generated token. The given token will no longer grant access to any endpoint.\nIf the token is invalid, does nothing. [More info](https://docs.avax.network/v1.0/en/api/auth/#authrevoketoken)"
+					},
+					"response": []
+				},
+				{
+					"name": "changePassword",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"auth.changePassword\",\n    \"params\": {\n        \"oldPassword\":\"old password goes here\",\n        \"newPassword\":\"new password goes here\"\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{http}}://{{host}}:{{port}}/ext/auth",
+							"protocol": "{{http}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"auth"
+							]
+						},
+						"description": "Change this node's authorization token password. Any authorization tokens created under an old password will become invalid. [More info](https://docs.avax.network/v1.0/en/api/auth/#authchangepassword)"
+					},
+					"response": []
+				}
+			],
+			"description": "This API can be used for measuring node health and debugging. [More info](https://docs.avax.network/v1.0/en/api/admin)",
+			"protocolProfileBehavior": {}
+		},
+		{
 			"name": "AVM",
 			"item": [
 				{
@@ -353,7 +450,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.exportAVAX\",\n    \"params\" :{\n        \"to\":\"{{pchainAddress}}\",\n        \"amount\": 100000,\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.exportAVAX\",\n    \"params\" :{\n        \"to\":\"P-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u\",\n        \"amount\": 4000001000000,\n        \"destinationChain\": \"P\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1672,36 +1769,6 @@
 					"response": []
 				},
 				{
-					"name": "getMinStake",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"info.getTxFee\",\n    \"params\": {\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/info",
-							"protocol": "{{http}}",
-							"host": [
-								"{{host}}"
-							],
-							"port": "{{port}}",
-							"path": [
-								"ext",
-								"info"
-							]
-						},
-						"description": "Get the minimum staking amount of the network. [More info](https://docs.avax.network/v1.0/en/api/info/#infogetminstake)"
-					},
-					"response": []
-				},
-				{
 					"name": "getNetworkID",
 					"request": {
 						"method": "POST",
@@ -2334,7 +2401,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.createSubnet\",\n    \"params\": {\n        \"controlKeys\":[\n            \"P-local1xx0upt9xfzxg0g2z2wjalxktnqe8c2pkk3w684\",\n            \"P-local17389pxz9esldtxfdfpvprfjw6r6pth7gu3zkcd\"\n        ],\n        \"threshold\":2,\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.createSubnet\",\n    \"params\": {\n        \"controlKeys\":[\n            \"{{pchainAddress}}\"\n        ],\n        \"threshold\":1,\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -2454,7 +2521,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.getCurrentValidators\",\n    \"params\": {},\n    \"id\": 1\n}",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.getCurrentValidators\",\n    \"params\": {\n        \"subnetID\": \"j87H8JFHc3wWQ8FQ3P8gGyu9UHdPcz3BcqNTvJKUG6AJ6DDpF\"\n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -2504,6 +2571,36 @@
 							]
 						},
 						"description": "Returns the height of the last accepted block [More info](https://docs.avax.network/v1.0/en/api/platform/#platformgetheight)"
+					},
+					"response": []
+				},
+				{
+					"name": "getMinStake",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getMinStake\",\n    \"params\": {}\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{http}}://{{host}}:{{port}}/ext/P",
+							"protocol": "{{http}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"P"
+							]
+						},
+						"description": "Returns the minimum stake amount [More info](https://docs.avax.network/v1.0/en/api/platform/#platformgetminstake)"
 					},
 					"response": []
 				},

--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -538,37 +538,6 @@
 					"response": []
 				},
 				{
-					"name": "exportAVAX",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.exportAVAX\",\n    \"params\" :{\n        \"from\": [\"{{xchainAddress}}\"],\n        \"to\":\"{{cchainbech32address}}\",\n        \"amount\": 4000001000000,\n        \"destinationChain\": \"C\",\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/X",
-							"protocol": "{{protocol}}",
-							"host": [
-								"{{host}}"
-							],
-							"port": "{{port}}",
-							"path": [
-								"ext",
-								"bc",
-								"X"
-							]
-						},
-						"description": "Export AVAX from the X-Chain to both the P-Chain as well as the C-Chain. After calling this method, you must call either the P-Chain’s `importAVAX` method or the C-Chain's `importAVAX` method to complete the transfer. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-exportavax)"
-					},
-					"response": []
-				},
-				{
 					"name": "exportKey",
 					"request": {
 						"method": "POST",
@@ -844,37 +813,6 @@
 							]
 						},
 						"description": "Finalize a transfer of AVAX from either the P-Chain to the X-Chain or the C-Chain to the X-Chain.\n\nBefore this method is called, you must call either the P-Chain’s `exportAVAX` method or the C-Chain’s `exportAVAX` method to initiate the transfer. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmimportavax)"
-					},
-					"response": []
-				},
-				{
-					"name": "importAVAX",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.importAVAX\",\n    \"params\" :{\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"sourceChain\": \"C\",\n        \"to\":\"{{xchainAddress}}\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/X",
-							"protocol": "{{protocol}}",
-							"host": [
-								"{{host}}"
-							],
-							"port": "{{port}}",
-							"path": [
-								"ext",
-								"bc",
-								"X"
-							]
-						},
-						"description": "Finalize a transfer of AVAX from either the P-Chain to the X-Chain or the C-Chain to the X-Chain.\n\nBefore this method is called, you must call either the P-Chain’s `exportAVAX` method or the C-Chain’s `exportAVAX` method to initiate the transfer. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-importavax)"
 					},
 					"response": []
 				},

--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -99,6 +99,66 @@
 					"response": []
 				},
 				{
+					"name": "getLoggerLevel",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"admin.getLoggerLevel\",\n    \"params\" :{\n        \"loggerName\":\"C\" \n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/admin",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"admin"
+							]
+						},
+						"description": "Returns log and display levels of loggers. [More info](https://docs.avax.network/build/avalanchego-apis/admin#admingetloggerlevel)"
+					},
+					"response": []
+				},
+				{
+					"name": "loadVMs",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"admin.loadVMs\",\n    \"params\" :{}\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/admin",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"admin"
+							]
+						},
+						"description": "Dynamically loads any virtual machines installed on the node as plugins. [More info](https://docs.avax.network/build/avalanchego-apis/admin#adminloadvms)"
+					},
+					"response": []
+				},
+				{
 					"name": "lockProfile",
 					"request": {
 						"method": "POST",
@@ -155,6 +215,36 @@
 							]
 						},
 						"description": "Dump the mutex statistics of the node to the specified file. [More info](https://docs.avax.network/build/apis/admin-api#admin-memoryprofile)"
+					},
+					"response": []
+				},
+				{
+					"name": "setLoggerLevel",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"admin.setLoggerLevel\",\n    \"params\" :{\n        \"loggerName\": \"C\",\n        \"logLevel\": \"DEBUG\",\n        \"displayLevel\": \"INFO\" \n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/admin",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"admin"
+							]
+						},
+						"description": "Sets log and display levels of loggers. [More info](https://docs.avax.network/build/avalanchego-apis/admin#adminsetloggerlevel)"
 					},
 					"response": []
 				},

--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -2722,7 +2722,7 @@
 							"response": []
 						},
 						{
-							"name": "getContainerByIndex Copy",
+							"name": "getContainerByID",
 							"request": {
 								"method": "POST",
 								"header": [],

--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -34,7 +34,7 @@
 								"admin"
 							]
 						},
-						"description": "Assign an API an alias, a different endpoint for the API. The original endpoint will still work. This change only affects this node; other nodes will not know about this alias. [More info](https://docs.avax.network/v1.0/en/api/admin/#adminalias)"
+						"description": "Assign an API an alias, a different endpoint for the API. The original endpoint will still work. This change only affects this node; other nodes will not know about this alias. [More info](https://docs.avax.network/build/apis/admin-api#admin-alias)"
 					},
 					"response": []
 				},
@@ -64,7 +64,7 @@
 								"admin"
 							]
 						},
-						"description": "Give a blockchain an alias, a different name that can be used any place the blockchain’s ID is used. [More info](https://docs.avax.network/v1.0/en/api/admin/#adminaliaschain)"
+						"description": "Give a blockchain an alias, a different name that can be used any place the blockchain’s ID is used. [More info](https://docs.avax.network/build/apis/admin-api#admin-aliaschain)"
 					},
 					"response": []
 				},
@@ -94,7 +94,7 @@
 								"admin"
 							]
 						},
-						"description": "Dump the mutex statistics of the node to the specified file. [More info](https://docs.avax.network/v1.0/en/api/admin/#adminlockprofile)"
+						"description": "Dump the mutex statistics of the node to the specified file. [More info](https://docs.avax.network/build/apis/admin-api#admin-lockprofile)"
 					},
 					"response": []
 				},
@@ -124,7 +124,7 @@
 								"admin"
 							]
 						},
-						"description": "Runs a memory profile writing to the specified file. [More info](https://docs.avax.network/v1.0/en/api/admin/#adminmemoryprofile)"
+						"description": "Dump the mutex statistics of the node to the specified file. [More info](https://docs.avax.network/build/apis/admin-api#admin-memoryprofile)"
 					},
 					"response": []
 				},
@@ -154,7 +154,7 @@
 								"admin"
 							]
 						},
-						"description": "Start profiling the CPU utilization of the node. Will write the profile to the specified file on stop. [More info](https://docs.avax.network/v1.0/en/api/admin/#adminstartcpuprofiler)"
+						"description": "Start profiling the CPU utilization of the node. Will write the profile to the specified file on stop. [More info](https://docs.avax.network/build/apis/admin-api#admin-startcpuprofiler)"
 					},
 					"response": []
 				},
@@ -184,7 +184,7 @@
 								"admin"
 							]
 						},
-						"description": "Stop the CPU profile that was previously started. [More info](https://docs.avax.network/v1.0/en/api/admin/#adminstopcpuprofiler)"
+						"description": "Stop the CPU profile that was previously started. [More info](https://docs.avax.network/build/apis/admin-api#admin-stopcpuprofiler)"
 					},
 					"response": []
 				}
@@ -221,7 +221,7 @@
 								"auth"
 							]
 						},
-						"description": "Creates a new authorization token that grants access to one or more API endpoints.\n (https://docs.avax.network/v1.0/en/api/auth/#authnewtoken)"
+						"description": "Creates a new authorization token that grants access to one or more API endpoints.\n [More info](https://docs.avax.network/build/apis/auth-api#auth-newtoken)"
 					},
 					"response": []
 				},
@@ -251,7 +251,7 @@
 								"auth"
 							]
 						},
-						"description": "Revoke a previously generated token. The given token will no longer grant access to any endpoint.\nIf the token is invalid, does nothing. [More info](https://docs.avax.network/v1.0/en/api/auth/#authrevoketoken)"
+						"description": "Revoke a previously generated token. The given token will no longer grant access to any endpoint.\nIf the token is invalid, does nothing. [More info](https://docs.avax.network/build/apis/auth-api#auth-revoketoken)"
 					},
 					"response": []
 				},
@@ -281,7 +281,7 @@
 								"auth"
 							]
 						},
-						"description": "Change this node's authorization token password. Any authorization tokens created under an old password will become invalid. [More info](https://docs.avax.network/v1.0/en/api/auth/#authchangepassword)"
+						"description": "Change this node's authorization token password. Any authorization tokens created under an old password will become invalid. [More info](https://docs.avax.network/build/apis/auth-api#auth-changepassword)"
 					},
 					"response": []
 				}
@@ -350,7 +350,7 @@
 								"X"
 							]
 						},
-						"description": "Create a new address controlled by the given user. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmcreateaddress)"
+						"description": "Create a new address controlled by the given user. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-createaddress)"
 					},
 					"response": []
 				},
@@ -381,7 +381,7 @@
 								"X"
 							]
 						},
-						"description": "Create a new fixed-cap, fungible asset. A quantity of it is created at initialization and then no more is ever created. The asset can be sent with `avm.send`. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmcreatefixedcapasset)"
+						"description": "Create a new fixed-cap, fungible asset. A quantity of it is created at initialization and then no more is ever created. The asset can be sent with `avm.send`. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-createfixedcapasset)"
 					},
 					"response": []
 				},
@@ -412,7 +412,7 @@
 								"X"
 							]
 						},
-						"description": "Create a new non-fungible asset. No units of the asset exist at initialization. Minters can mint units of this asset using `mintTx` and `signMintTx`. The asset can be sent with `avm.sendNFT`. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmcreatenftasset)"
+						"description": "Create a new non-fungible asset. No units of the asset exist at initialization. Minters can mint units of this asset using `mintTx` and `signMintTx`. The asset can be sent with `avm.sendNFT`. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-createnftasset)"
 					},
 					"response": []
 				},
@@ -443,7 +443,7 @@
 								"X"
 							]
 						},
-						"description": "Create a new variable-cap, fungible asset. No units of the asset exist at initialization. Minters can mint units of this asset using `createMintTx`, `signMintTx` and `issueTx`. The asset can be sent with `avm.send`. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmcreatevariablecapasset)"
+						"description": "Create a new variable-cap, fungible asset. No units of the asset exist at initialization. Minters can mint units of this asset using `createMintTx`, `signMintTx` and `issueTx`. The asset can be sent with `avm.send`. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-createvariablecapasset)"
 					},
 					"response": []
 				},
@@ -454,7 +454,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.export\",\n    \"params\" :{\n        \"to\":\"{{cchainbech32address}}\",\n        \"amount\": 50,\n        \"assetID\": \"2W4XDTMrQJm7YALcnCL4krU7JpoGQQaDkTdn2HbzpsqombHRaB\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.export\",\n    \"params\" :{\n        \"from\": [\"{{xchainAddress}}\"],\n        \"to\":\"{{cchainbech32address}}\",\n        \"amount\": 50,\n        \"assetID\": \"2YmsQfMaCczE4mLG1DPYUnRURNGfhjj4qrqnLRR3LmZ3GxDWPt\",\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -505,7 +505,7 @@
 								"X"
 							]
 						},
-						"description": "Export AVAX from the X-Chain to both the P-Chain as well as the C-Chain. After calling this method, you must call either the P-Chain’s `importAVAX` method or the C-Chain's `importAVAX` method to complete the transfer. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmexportavax)"
+						"description": "Export AVAX from the X-Chain to both the P-Chain as well as the C-Chain. After calling this method, you must call either the P-Chain’s `importAVAX` method or the C-Chain's `importAVAX` method to complete the transfer. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-exportavax)"
 					},
 					"response": []
 				},
@@ -536,7 +536,7 @@
 								"X"
 							]
 						},
-						"description": "Get the private key that controls a given address.\nThe returned private key can be added to a user with `avm.importKey`. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmexportkey)\n\n"
+						"description": "Get the private key that controls a given address.\nThe returned private key can be added to a user with `avm.importKey`. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-exportkey)"
 					},
 					"response": []
 				},
@@ -567,7 +567,7 @@
 								"X"
 							]
 						},
-						"description": "Get the balances of all assets controlled by a given address. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmgetallbalances)"
+						"description": "Get the balances of all assets controlled by a given address. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-getallbalances)"
 					},
 					"response": []
 				},
@@ -598,7 +598,7 @@
 								"X"
 							]
 						},
-						"description": "Get information about an asset. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmgetassetdescription)"
+						"description": "Get information about an asset. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-getassetdescription)"
 					},
 					"response": []
 				},
@@ -660,7 +660,7 @@
 								"X"
 							]
 						},
-						"description": "Get the balance of an asset controlled by a given address. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmgetbalance)"
+						"description": "Get the balance of an asset controlled by a given address. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-getbalance)"
 					},
 					"response": []
 				},
@@ -691,7 +691,7 @@
 								"X"
 							]
 						},
-						"description": "Returns the specified transaction [More info](https://docs.avax.network/v1.0/en/api/avm/#avmgetbalance)"
+						"description": "Returns the specified transaction [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-gettx)"
 					},
 					"response": []
 				},
@@ -722,7 +722,7 @@
 								"X"
 							]
 						},
-						"description": "Get the status of a transaction sent to the network. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmgettxstatus)"
+						"description": "Get the status of a transaction sent to the network. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-gettxstatus)"
 					},
 					"response": []
 				},
@@ -753,7 +753,7 @@
 								"X"
 							]
 						},
-						"description": "Get the UTXOs that reference a given address. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmgetutxos)"
+						"description": "Get the UTXOs that reference a given address. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-getutxos)"
 					},
 					"response": []
 				},
@@ -815,7 +815,7 @@
 								"X"
 							]
 						},
-						"description": "Finalize a transfer of AVAX from either the P-Chain to the X-Chain or the C-Chain to the X-Chain.\n\nBefore this method is called, you must call either the P-Chain’s `exportAVAX` method or the C-Chain’s `exportAVAX` method to initiate the transfer. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmimportavax)"
+						"description": "Finalize a transfer of AVAX from either the P-Chain to the X-Chain or the C-Chain to the X-Chain.\n\nBefore this method is called, you must call either the P-Chain’s `exportAVAX` method or the C-Chain’s `exportAVAX` method to initiate the transfer. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-importavax)"
 					},
 					"response": []
 				},
@@ -846,7 +846,7 @@
 								"X"
 							]
 						},
-						"description": "Give a user control over an address by providing the private key that controls the address. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmimportkey)"
+						"description": "Give a user control over an address by providing the private key that controls the address. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-importkey)"
 					},
 					"response": []
 				},
@@ -877,7 +877,7 @@
 								"X"
 							]
 						},
-						"description": "Send a signed transaction to the network. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmissuetx)"
+						"description": "Send a signed transaction to the network. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-issuetx)"
 					},
 					"response": []
 				},
@@ -908,7 +908,7 @@
 								"X"
 							]
 						},
-						"description": "List addresses controlled by the given user. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmlistaddresses)"
+						"description": "List addresses controlled by the given user. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-listaddresses)"
 					},
 					"response": []
 				},
@@ -939,7 +939,7 @@
 								"X"
 							]
 						},
-						"description": "Create an unsigned transaction to mint more of a variable-cap asset (an asset created with `avm.createVariableCapAsset`.) [More info](https://docs.avax.network/v1.0/en/api/avm/#avmcreateminttx)"
+						"description": "Create an unsigned transaction to mint more of a variable-cap asset (an asset created with `avm.createVariableCapAsset`.) [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-mint)"
 					},
 					"response": []
 				},
@@ -970,7 +970,7 @@
 								"X"
 							]
 						},
-						"description": "Mint more of a non-fungible asset (an asset created with `avm.createNFTAsset`.) [More info](https://docs.avax.network/v1.0/en/api/avm/#avmmintnft)"
+						"description": "Mint more of a non-fungible asset (an asset created with `avm.createNFTAsset`.) [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-mintnft)"
 					},
 					"response": []
 				},
@@ -1001,7 +1001,7 @@
 								"X"
 							]
 						},
-						"description": "Send a quantity of an asset to an address. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmsend)"
+						"description": "Send a quantity of an asset to an address. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-send)"
 					},
 					"response": []
 				},
@@ -1032,7 +1032,7 @@
 								"X"
 							]
 						},
-						"description": "Send a quantity of an asset to an address. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmsend)"
+						"description": "Send a quantity of an asset to an address. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-sendmultiple)"
 					},
 					"response": []
 				},
@@ -1063,7 +1063,7 @@
 								"X"
 							]
 						},
-						"description": "Send a quantity of an asset to an address. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmsend)"
+						"description": "Send a quantity of an asset to an address. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-sendnft)"
 					},
 					"response": []
 				}
@@ -1102,7 +1102,7 @@
 								"rpc"
 							]
 						},
-						"description": "Getting the most recent block number. [More info](https://docs.avax.network/v1.0/en/api/evm/#getting-the-most-recent-block-number)"
+						"description": "Getting the most recent block number. [More info](https://docs.avax.network/build/apis/contract-chain-c-chain-api#getting-the-most-recent-block-number)"
 					},
 					"response": []
 				},
@@ -1134,7 +1134,7 @@
 								"rpc"
 							]
 						},
-						"description": "Call a contract. [More info](https://docs.avax.network/v1.0/en/api/evm/#call-a-contract)"
+						"description": "Call a contract. [More info](https://docs.avax.network/build/apis/contract-chain-c-chain-api#call-a-contract)"
 					},
 					"response": []
 				},
@@ -1166,7 +1166,7 @@
 								"rpc"
 							]
 						},
-						"description": "Not well documented in JSON-RPC references. See instead EIP694. [More info](https://docs.avax.network/v1.0/en/api/evm/#getting-the-chain-id)"
+						"description": "Not well documented in JSON-RPC references. See instead EIP694. [More info](https://docs.avax.network/build/apis/contract-chain-c-chain-api#getting-the-chain-id)"
 					},
 					"response": []
 				},
@@ -1230,7 +1230,7 @@
 								"rpc"
 							]
 						},
-						"description": "Getting an account’s balance. [More info](https://docs.avax.network/v1.0/en/api/evm/#getting-an-accounts-balance)"
+						"description": "Getting an account’s balance. [More info](https://docs.avax.network/build/apis/contract-chain-c-chain-api#getting-an-accounts-balance)"
 					},
 					"response": []
 				},
@@ -1262,7 +1262,7 @@
 								"rpc"
 							]
 						},
-						"description": "Signing a transaction.\n\nThis method will create a signed transaction, but will not publish it automatically to the network. Instead, the `raw` result output should be used with `eth_sendRawTransaction` to execute the transaction. [More info](https://docs.avax.network/v1.0/en/api/evm/#signing-a-transaction)"
+						"description": "Signing a transaction.\n\nThis method will create a signed transaction, but will not publish it automatically to the network. Instead, the `raw` result output should be used with `eth_sendRawTransaction` to execute the transaction. [More info](https://docs.avax.network/build/apis/contract-chain-c-chain-api#signing-a-transaction)"
 					},
 					"response": []
 				},
@@ -1294,7 +1294,7 @@
 								"rpc"
 							]
 						},
-						"description": "Getting an account’s nonce. [More info](https://docs.avax.network/v1.0/en/api/evm/#getting-an-accounts-nonce)"
+						"description": "Getting an account’s nonce. [More info](https://docs.avax.network/build/apis/contract-chain-c-chain-api#getting-an-accounts-nonce)"
 					},
 					"response": []
 				},
@@ -1326,7 +1326,7 @@
 								"rpc"
 							]
 						},
-						"description": "Send a raw transaction.\n\nExample below shows a raw transaction published to the network and its associated transaction hash. [More info](https://docs.avax.network/v1.0/en/api/evm/#send-a-raw-transaction)"
+						"description": "Send a raw transaction.\n\nExample below shows a raw transaction published to the network and its associated transaction hash. [More info](https://docs.avax.network/build/apis/contract-chain-c-chain-api#send-a-raw-transaction)"
 					},
 					"response": []
 				},
@@ -1358,7 +1358,7 @@
 								"rpc"
 							]
 						},
-						"description": "Getting a block by hash. [More info](https://docs.avax.network/v1.0/en/api/evm/#getting-a-block-by-hash)"
+						"description": "Getting a block by hash. [More info](https://docs.avax.network/build/apis/contract-chain-c-chain-api#getting-a-block-by-hash)"
 					},
 					"response": []
 				},
@@ -1555,6 +1555,102 @@
 					"response": []
 				},
 				{
+					"name": "getTx",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avax.getTx\",\n    \"params\" :{\n        \"txID\":\"2LVVdbsbg7Lkp3bVBzbJeopp8HfBMApefoHLZ7VaFkXPPvd7KJ\"\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/avax",
+							"protocol": "{{http}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"bc",
+								"C",
+								"avax"
+							]
+						},
+						"description": "Returns the specified transaction [More info](https://docs.avax.network/v1.0/en/api/avm/#avmgetbalance)"
+					},
+					"response": []
+				},
+				{
+					"name": "getTxStatus",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"id\": 1,\n    \"method\": \"avax.getTxStatus\",\n    \"params\": {\n        \"txID\": \"2LVVdbsbg7Lkp3bVBzbJeopp8HfBMApefoHLZ7VaFkXPPvd7KJ\"\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/avax",
+							"protocol": "{{http}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"bc",
+								"C",
+								"avax"
+							]
+						},
+						"description": "Get the status of a transaction sent to the network. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmgettxstatus)"
+					},
+					"response": []
+				},
+				{
+					"name": "getUTXOs",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avax.getUTXOs\",\n    \"params\" :{\n        \"addresses\":[\"{{cchainbech32address}}\"],\n        \"sourceChain\": \"X\",\n        \"limit\": 5\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/avax",
+							"protocol": "{{http}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"bc",
+								"C",
+								"avax"
+							]
+						},
+						"description": "Get the UTXOs that reference a given address. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmgetutxos)"
+					},
+					"response": []
+				},
+				{
 					"name": "import",
 					"request": {
 						"method": "POST",
@@ -1647,6 +1743,38 @@
 							]
 						},
 						"description": "Give a user control over an address by providing the private key that controls the address. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmimportkey)"
+					},
+					"response": []
+				},
+				{
+					"name": "issueTx",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avax.issueTx\",\n    \"params\" :{\n        \"tx\":\"6sTENqXfk3gahxkJbEPsmX9eJTEFZRSRw83cRJqoHWBiaeAhVbz9QV4i6SLd6Dek4eLsojeR8FbT3arFtsGz9ycpHFaWHLX69edJPEmj2tPApsEqsFd7wDVp7fFxkG6HmySR\"\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/avax",
+							"protocol": "{{http}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"bc",
+								"C",
+								"avax"
+							]
+						},
+						"description": "Send a signed transaction to the network. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-issuetx)"
 					},
 					"response": []
 				},
@@ -1939,7 +2067,7 @@
 								"health"
 							]
 						},
-						"description": "Get health check on this node. [More info](https://docs.avax.network/v1.0/en/api/health/#healthgetliveness)"
+						"description": "Get health check on this node. [More info](https://docs.avax.network/build/apis/health-api#health-getliveness)"
 					},
 					"response": []
 				}
@@ -1976,7 +2104,7 @@
 								"info"
 							]
 						},
-						"description": "Given a blockchain’s alias, get its ID. [More info](https://docs.avax.network/v1.0/en/api/info/#infogetblockchainid)"
+						"description": "Given a blockchain’s alias, get its ID. [More info](https://docs.avax.network/build/apis/info-api#info-getblockchainid)"
 					},
 					"response": []
 				},
@@ -2006,7 +2134,7 @@
 								"info"
 							]
 						},
-						"description": "Get the ID of the network this node is participating in. [More info](https://docs.avax.network/v1.0/en/api/info/#infogetnetworkid)"
+						"description": "Get the ID of the network this node is participating in. [More info](https://docs.avax.network/build/apis/info-api#info-getnetworkid)"
 					},
 					"response": []
 				},
@@ -2036,7 +2164,7 @@
 								"info"
 							]
 						},
-						"description": "Get the name of the network this node is participating in. [More info](https://docs.avax.network/v1.0/en/api/info/#infogetnetworkname)"
+						"description": "Get the name of the network this node is participating in. [More info](https://docs.avax.network/build/apis/info-api#info-getnetworkname)"
 					},
 					"response": []
 				},
@@ -2066,7 +2194,37 @@
 								"info"
 							]
 						},
-						"description": "Get the name of the network this node is participating in. [More info](https://docs.avax.network/v1.0/en/api/info/#infogetnodeid)"
+						"description": "Get the name of the network this node is participating in. [More info](https://docs.avax.network/build/apis/info-api#info-getnodeid)"
+					},
+					"response": []
+				},
+				{
+					"name": "getNodeIP",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"info.getNodeIP\",\n    \"params\" :{\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{http}}://{{host}}:{{port}}/ext/info",
+							"protocol": "{{http}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"info"
+							]
+						},
+						"description": "Get the IP of this node. [More info](https://docs.avax.network/build/apis/info-api#info-getnodeip)"
 					},
 					"response": []
 				},
@@ -2096,7 +2254,7 @@
 								"info"
 							]
 						},
-						"description": "Get the version of this node. [More info](https://docs.avax.network/v1.0/en/api/info/#infogetnodeversion)"
+						"description": "Get the version of this node. [More info](https://docs.avax.network/build/apis/info-api#info-getnodeversion)"
 					},
 					"response": []
 				},
@@ -2126,7 +2284,7 @@
 								"info"
 							]
 						},
-						"description": "Check whether a given chain is done bootstrapping. [More info](https://docs.avax.network/v1.0/en/api/info/#infoisbootstrapped)"
+						"description": "Check whether a given chain is done bootstrapping. [More info](https://docs.avax.network/build/apis/info-api#info-isbootstrapped)"
 					},
 					"response": []
 				},
@@ -2186,7 +2344,7 @@
 								"info"
 							]
 						},
-						"description": "Get description of peer connections. [More info](https://docs.avax.network/v1.0/en/api/info/#infopeers)"
+						"description": "Get description of peer connections. [More info](https://docs.avax.network/build/apis/info-api#info-peers)"
 					},
 					"response": []
 				}
@@ -2223,7 +2381,7 @@
 								"ipcs"
 							]
 						},
-						"description": "Register a blockchain so it publishes accepted vertices to a Unix domain socket. [More info](https://docs.avax.network/v1.0/en/api/ipc/#ipcspublishblockchain)"
+						"description": "Register a blockchain so it publishes accepted vertices to a Unix domain socket. [More info](https://docs.avax.network/build/apis/ipc-api#ipcs-publishblockchain)"
 					},
 					"response": []
 				},
@@ -2253,7 +2411,7 @@
 								"ipcs"
 							]
 						},
-						"description": "Deregister a blockchain so that it no longer publishes to a Unix domain socket. [More info](https://docs.avax.network/v1.0/en/api/ipc/#ipcspublishblockchain)"
+						"description": "Deregister a blockchain so that it no longer publishes to a Unix domain socket. [More info](https://docs.avax.network/build/apis/ipc-api#ipcs-unpublishblockchain)"
 					},
 					"response": []
 				}
@@ -2290,7 +2448,7 @@
 								"keystore"
 							]
 						},
-						"description": "Create a new user with the specified username and password. [More info](https://docs.avax.network/v1.0/en/api/keystore/#keystorecreateuser)"
+						"description": "Create a new user with the specified username and password. [More info](https://docs.avax.network/build/apis/keystore-api#keystore-createuser)"
 					},
 					"response": []
 				},
@@ -2320,7 +2478,7 @@
 								"keystore"
 							]
 						},
-						"description": "Delete a user. [More info](https://docs.avax.network/v1.0/en/api/keystore/#kesytoredeleteuser)"
+						"description": "Delete a user. [More info](https://docs.avax.network/build/apis/keystore-api#keystore-deleteuser)"
 					},
 					"response": []
 				},
@@ -2350,7 +2508,7 @@
 								"keystore"
 							]
 						},
-						"description": "Export a user. The user can be imported to another node with `keystore.importUser`. The user’s password remains encrypted. [More info](https://docs.avax.network/v1.0/en/api/keystore/#keystoreexportuser)"
+						"description": "Export a user. The user can be imported to another node with `keystore.importUser`. The user’s password remains encrypted. [More info](https://docs.avax.network/build/apis/keystore-api#keystore-exportuser)"
 					},
 					"response": []
 				},
@@ -2380,7 +2538,7 @@
 								"keystore"
 							]
 						},
-						"description": "Import a user. `password` must match the user’s password. `username` doesn’t have to match the username `user` had when it was exported. [More info](https://docs.avax.network/v1.0/en/api/keystore/#keystoreimportuser)"
+						"description": "Import a user. `password` must match the user’s password. `username` doesn’t have to match the username `user` had when it was exported. [More info](https://docs.avax.network/build/apis/keystore-api#keystore-importuser)"
 					},
 					"response": []
 				},
@@ -2410,7 +2568,7 @@
 								"keystore"
 							]
 						},
-						"description": "List the users in this keystore. [More info](https://docs.avax.network/v1.0/en/api/keystore/#keystorelistusers)"
+						"description": "List the users in this keystore. [More info](https://docs.avax.network/build/apis/keystore-api#keystore-listusers)"
 					},
 					"response": []
 				}
@@ -2445,7 +2603,7 @@
 								"metrics"
 							]
 						},
-						"description": "To get the node metrics. [More info](https://docs.avax.network/v1.0/en/api/metrics)"
+						"description": "To get the node metrics. [More info](https://docs.avax.network/build/apis/metrics-api)"
 					},
 					"response": []
 				}

--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -3795,6 +3795,37 @@
 					"response": []
 				},
 				{
+					"name": "getRewardUTXOs",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getRewardUTXOs\",\n    \"params\" :{\n        \"txID\":\"2nmH8LithVbdjaXsxVQCQfXtzN9hBbmebrsaEYnLM9T32Uy2Y4\"\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"bc",
+								"P"
+							]
+						},
+						"description": "Returns the UTXOs that were rewarded after the provided transaction's staking or delegation period ended."
+					},
+					"response": []
+				},
+				{
 					"name": "getStake",
 					"request": {
 						"method": "POST",

--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -327,7 +327,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"id\"     : 1,\n    \"method\" : \"avm.buildGenesis\",\n    \"params\" : {\n        \"genesisData\": {\n            \"asset1\": {\n                \"name\": \"myFixedCapAsset\",\n                \"symbol\":\"MFCA\",\n                \"initialState\": {\n                    \"fixedCap\" : [\n                        {\n                            \"amount\":100000,\n                            \"address\": \"local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u\"\n                        }\n                    ]\n                }\n            },\n            \"asset2\": {\n                \"name\": \"myVarCapAsset\",\n                \"symbol\":\"MVCA\",\n                \"initialState\": {\n                    \"variableCap\" : [\n                        {\n                            \"minters\": [\n                                \"local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u\"\n                            ],\n                            \"threshold\":1\n                        }\n                    ]\n                }\n            }\n        }\n    }\n}",
+              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"id\"     : 1,\n    \"method\" : \"avm.buildGenesis\",\n    \"params\" : {\n        \"genesisData\": {\n            \"asset1\": {\n                \"name\": \"asset1\",\n                \"symbol\":\"MFCA\",\n                \"memo\": \"2Zc54v4ek37TEwu4LiV3j41PUMRd6acDDU3ZCVSxE7X\",\n                \"denomination\": 1, \n                \"initialState\": {\n                    \"fixedCap\" : [\n                        {\n                            \"amount\":100000,\n                            \"address\": \"local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u\"\n                        }\n                    ]\n                }\n            },\n            \"asset2\": {\n                \"name\": \"asset2\",\n                \"symbol\":\"MVCA\",\n                \"memo\": \"2Zc54v4ek37TEwu4LiV3j41PUMRd6acDDU3ZCVSxE7X\",\n                \"denomination\": 2, \n                \"initialState\": {\n                    \"variableCap\" : [\n                        {\n                            \"amount\":100000,\n                            \"address\": \"local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u\"\n                        }\n                    ]\n                }\n            }\n        },\n        \"networkId\": 12345\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1195,6 +1195,38 @@
 			"name": "EVM",
 			"item": [
 				{
+          "name": "eth_baseFee",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_baseFee\",\n    \"params\": [],\n    \"id\": 1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/rpc",
+              "protocol": "{{protocol}}",
+              "host": [
+                "{{host}}"
+              ],
+              "port": "{{port}}",
+              "path": [
+                "ext",
+                "bc",
+                "C",
+                "rpc"
+              ]
+            },
+            "description": "Get the base fee for the next block. [More info](https://docs.avax.network/build/apis/contract-chain-c-chain-api#eth_baseFee)"
+          },
+          "response": []
+        },
+        {
 					"name": "eth_blockNumber",
 					"request": {
 						"method": "POST",
@@ -1355,6 +1387,38 @@
 					"response": []
 				},
 				{
+          "name": "eth_maxPriorityFeePerGas",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_maxPriorityFeePerGas\",\n    \"params\": [],\n    \"id\": 1\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/rpc",
+              "protocol": "{{protocol}}",
+              "host": [
+                "{{host}}"
+              ],
+              "port": "{{port}}",
+              "path": [
+                "ext",
+                "bc",
+                "C",
+                "rpc"
+              ]
+            },
+            "description": "Get the priority fee needed to be included in a block. [More info](https://docs.avax.network/build/apis/contract-chain-c-chain-api#eth_maxPriorityFeePerGas)"
+          },
+          "response": []
+        },
+        {
 					"name": "eth_signTransaction",
 					"request": {
 						"method": "POST",
@@ -3460,7 +3524,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.addSubnetValidator\",\n    \"params\": {\n        \"nodeID\":\"{{avalancheNodeId}}\",\n        \"subnetID\":\"{{avalancheSubnetId}}\",\n        \"startTime\":1583524047,\n        \"endTime\":1604102399,\n        \"weight\":1,\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
+              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.addSubnetValidator\",\n    \"params\": {\n        \"nodeID\":\"{{avalancheNodeId}}\",\n        \"subnetID\":\"{{avalancheSubnetId}}\",\n        \"startTime\":1625782598,\n        \"endTime\":1627078419,\n        \"weight\":20,\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -3639,7 +3703,7 @@
 					},
 					"response": []
 				},
-				{
+        {
 					"name": "getBlockchainStatus",
 					"request": {
 						"method": "POST",

--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -731,7 +731,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.getUTXOs\",\n    \"params\" :{\n        \"addresses\":[\"{{xchainAddress}}\"],\n        \"limit\": 5\n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.getUTXOs\",\n    \"params\" :{\n        \"addresses\":[\"{{xchainAddress}}\"],\n        \"limit\": 5,\n        \"sourceChain\": \"X\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"

--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -327,7 +327,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"id\"     : 1,\n    \"method\" : \"avm.buildGenesis\",\n    \"params\" : {\n        \"genesisData\": {\n            \"asset1\": {\n                \"name\": \"asset1\",\n                \"symbol\":\"MFCA\",\n                \"memo\": \"2Zc54v4ek37TEwu4LiV3j41PUMRd6acDDU3ZCVSxE7X\",\n                \"denomination\": 1, \n                \"initialState\": {\n                    \"fixedCap\" : [\n                        {\n                            \"amount\":100000,\n                            \"address\": \"local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u\"\n                        }\n                    ]\n                }\n            },\n            \"asset2\": {\n                \"name\": \"asset2\",\n                \"symbol\":\"MVCA\",\n                \"memo\": \"2Zc54v4ek37TEwu4LiV3j41PUMRd6acDDU3ZCVSxE7X\",\n                \"denomination\": 2, \n                \"initialState\": {\n                    \"variableCap\" : [\n                        {\n                            \"amount\":100000,\n                            \"address\": \"local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u\"\n                        }\n                    ]\n                }\n            }\n        },\n        \"networkId\": 12345\n    }\n}",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"id\"     : 1,\n    \"method\" : \"avm.buildGenesis\",\n    \"params\" : {\n        \"genesisData\": {\n            \"asset1\": {\n                \"name\": \"asset1\",\n                \"symbol\":\"MFCA\",\n                \"memo\": \"2Zc54v4ek37TEwu4LiV3j41PUMRd6acDDU3ZCVSxE7X\",\n                \"denomination\": 1, \n                \"initialState\": {\n                    \"fixedCap\" : [\n                        {\n                            \"amount\":100000,\n                            \"address\": \"local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u\"\n                        }\n                    ]\n                }\n            },\n            \"asset2\": {\n                \"name\": \"asset2\",\n                \"symbol\":\"MVCA\",\n                \"memo\": \"2Zc54v4ek37TEwu4LiV3j41PUMRd6acDDU3ZCVSxE7X\",\n                \"denomination\": 2, \n                \"initialState\": {\n                    \"variableCap\" : [\n                        {\n                            \"amount\":100000,\n                            \"address\": \"local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u\"\n                        }\n                    ]\n                }\n            }\n        },\n        \"networkId\": 12345,\n        \"encoding\":\"cb58\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -792,7 +792,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.getUTXOs\",\n    \"params\" :{\n        \"addresses\":[\"{{xchainAddress}}\"],\n        \"limit\": 5,\n        \"sourceChain\": \"X\"\n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.getUTXOs\",\n    \"params\" :{\n        \"addresses\":[\"{{xchainAddress}}\"],\n        \"limit\": 5,\n        \"sourceChain\": \"X\",\n        \"encoding\": \"hex\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -885,7 +885,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.issueTx\",\n    \"params\" :{\n        \"tx\":\"6sTENqXfk3gahxkJbEPsmX9eJTEFZRSRw83cRJqoHWBiaeAhVbz9QV4i6SLd6Dek4eLsojeR8FbT3arFtsGz9ycpHFaWHLX69edJPEmj2tPApsEqsFd7wDVp7fFxkG6HmySR\"\n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.issueTx\",\n    \"params\" :{\n        \"tx\":\"6sTENqXfk3gahxkJbEPsmX9eJTEFZRSRw83cRJqoHWBiaeAhVbz9QV4i6SLd6Dek4eLsojeR8FbT3arFtsGz9ycpHFaWHLX69edJPEmj2tPApsEqsFd7wDVp7fFxkG6HmySR\",\n        \"encoding\": \"hex\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1009,7 +1009,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.mintNFT\",\n    \"params\" :{\n        \"assetID\":\"2KGdt2HpFKpTH5CtGZjYt5XPWs6Pv9DLoRBhiFfntbezdRvZWP\",\n        \"payload\":\"2EWh72jYQvEJF9NLk\",\n        \"from\": [\"{{xchainAddress}}\"],\n        \"to\":\"{{xchainAddress}}\",\n        \"minters\":[\n            \"{{xchainAddress}}\"\n        ],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.mintNFT\",\n    \"params\" :{\n        \"assetID\":\"2KGdt2HpFKpTH5CtGZjYt5XPWs6Pv9DLoRBhiFfntbezdRvZWP\",\n        \"payload\":\"2EWh72jYQvEJF9NLk\",\n        \"from\": [\"{{xchainAddress}}\"],\n        \"to\":\"{{xchainAddress}}\",\n        \"minters\":[\n            \"{{xchainAddress}}\"\n        ],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" ,\n        \"encoding\": \"hex\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1040,7 +1040,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.send\",\n    \"params\" :{ \n        \"assetID\" : \"{{avaxAssetId}}\",\n        \"amount\"  : 2000000000,\n        \"from\"    : [\"{{xchainAddress}}\"],\n        \"to\"      : \"X-local1q8ayy4dxap07fvm3k8fydgsac3wt4eh933pmt6\",\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"memo\"    : \"\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\" \n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.send\",\n    \"params\" :{ \n        \"assetID\" : \"{{avaxAssetId}}\",\n        \"amount\"  : 2000000000,\n        \"from\"    : [\"{{xchainAddress}}\"],\n        \"to\"      : \"{{xchainAddress}}\",\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"memo\"    : \"\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\" \n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1745,7 +1745,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avax.getAtomicTx\",\n    \"params\" :{\n        \"txID\":\"2GD5SRYJQr2kw5jE73trBFiAgVQyrCaeg223TaTyJFYXf2kPty\",\n        \"encoding\": \"cb58\"\n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avax.getAtomicTx\",\n    \"params\" :{\n        \"txID\":\"2GD5SRYJQr2kw5jE73trBFiAgVQyrCaeg223TaTyJFYXf2kPty\",\n        \"encoding\": \"hex\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1809,7 +1809,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avax.getUTXOs\",\n    \"params\" :{\n        \"addresses\":[\"{{cchainbech32address}}\"],\n        \"sourceChain\": \"X\",\n        \"limit\": 5\n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avax.getUTXOs\",\n    \"params\" :{\n        \"addresses\":[\"{{cchainbech32address}}\"],\n        \"sourceChain\": \"X\",\n        \"limit\": 5,\n        \"encoding\": \"hex\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1937,7 +1937,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avax.issueTx\",\n    \"params\" :{\n        \"tx\":\"6sTENqXfk3gahxkJbEPsmX9eJTEFZRSRw83cRJqoHWBiaeAhVbz9QV4i6SLd6Dek4eLsojeR8FbT3arFtsGz9ycpHFaWHLX69edJPEmj2tPApsEqsFd7wDVp7fFxkG6HmySR\"\n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avax.issueTx\",\n    \"params\" :{\n        \"tx\":\"0x00\",\n        \"encoding\": \"hex\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -2250,7 +2250,7 @@
 								"health"
 							]
 						},
-						"description": "Get health check on this node. [More info](https://docs.avax.network/build/apis/health-api#health-health)"
+						"description": "Get health check on this node. [More info](https://docs.avax.network/build/apis/health-api#health-getliveness)"
 					},
 					"response": []
 				}
@@ -2270,7 +2270,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getLastAccepted\",\n    \"params\": {\n        \"encoding\":\"cb58\"\n    }\n}",
+									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getLastAccepted\",\n    \"params\": {\n        \"encoding\":\"hex\"\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -2291,7 +2291,7 @@
 										"tx"
 									]
 								},
-								"description": "Get the most recently accepted container. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index-getlastaccepted)"
+								"description": "Get the most recently accepted container. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getlastaccepted)"
 							},
 							"response": []
 						},
@@ -2302,7 +2302,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerByIndex\",\n    \"params\": {\n        \"index\":0,\n        \"encoding\":\"cb58\"\n    }\n}",
+									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerByIndex\",\n    \"params\": {\n        \"index\":0,\n        \"encoding\":\"hex\"\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -2323,7 +2323,39 @@
 										"tx"
 									]
 								},
-								"description": "Get container by index. The first container accepted is at index 0, the second is at index 1, etc. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index-getcontainerbyindex)"
+								"description": "Get container by index. The first container accepted is at index 0, the second is at index 1, etc. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getcontainerbyindex)"
+							},
+							"response": []
+						},
+						{
+							"name": "getContainerByID",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerByID\",\n    \"params\": {\n        \"containerID\":\"2dGz8JSfX17QqW12pARrt2iWNhXdcpXMYPVSYRn9HrReGpMXqQ\",\n        \"encoding\":\"hex\"\n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{protocol}}://{{host}}:{{port}}/ext/index/X/tx",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"ext",
+										"index",
+										"X",
+										"tx"
+									]
+								},
+								"description": "Get container by ID. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getcontainerbyid)"
 							},
 							"response": []
 						},
@@ -2334,7 +2366,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerRange\",\n    \"params\": {\n        \"startIndex\":0,\n        \"numtoFetch\":10,\n        \"encoding\":\"cb58\"\n    }\n}",
+									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerRange\",\n    \"params\": {\n        \"startIndex\":0,\n        \"numtoFetch\":10,\n        \"encoding\":\"hex\"\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -2355,7 +2387,7 @@
 										"tx"
 									]
 								},
-								"description": "Returns containers with indices in [startIndex, startIndex+1, ... , startIndex + numToFetch - 1]. numToFetch must be in \\[0,1024\\] [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index-getcontainerrange)"
+								"description": "Returns containers with indices in [startIndex, startIndex+1, ... , startIndex + numToFetch - 1]. numToFetch must be in \\[0,1024\\] [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getcontainerrange)"
 							},
 							"response": []
 						},
@@ -2366,7 +2398,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getIndex\",\n    \"params\": {\n        \"containerID\":\"6fXf5hncR8LXvwtM8iezFQBpK5cubV6y1dWgpJCcNyzGB1EzY\",\n        \"encoding\":\"cb58\"\n    }\n}",
+									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getIndex\",\n    \"params\": {\n        \"containerID\":\"2dGz8JSfX17QqW12pARrt2iWNhXdcpXMYPVSYRn9HrReGpMXqQ\",\n        \"encoding\":\"hex\"\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -2387,7 +2419,7 @@
 										"tx"
 									]
 								},
-								"description": "Get a container's index. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index-getindex)"
+								"description": "Get a container's index. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getindex)"
 							},
 							"response": []
 						},
@@ -2398,7 +2430,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.isAccepted\",\n    \"params\": {\n        \"containerID\":\"6fXf5hncR8LXvwtM8iezFQBpK5cubV6y1dWgpJCcNyzGB1EzY\",\n        \"encoding\":\"cb58\"\n    }\n}",
+									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.isAccepted\",\n    \"params\": {\n        \"containerID\":\"2dGz8JSfX17QqW12pARrt2iWNhXdcpXMYPVSYRn9HrReGpMXqQ\",\n        \"encoding\":\"hex\"\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -2419,7 +2451,7 @@
 										"tx"
 									]
 								},
-								"description": "Returns true if the container is in this index. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index-isaccepted)"
+								"description": "Returns true if the container is in this index. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.isaccepted)"
 							},
 							"response": []
 						}
@@ -2435,7 +2467,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getLastAccepted\",\n    \"params\": {\n        \"encoding\":\"cb58\"\n    }\n}",
+									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getLastAccepted\",\n    \"params\": {\n        \"encoding\":\"hex\"\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -2456,7 +2488,7 @@
 										"vtx"
 									]
 								},
-								"description": "Get the most recently accepted container. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index-getlastaccepted)"
+								"description": "Get the most recently accepted container. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getlastaccepted)"
 							},
 							"response": []
 						},
@@ -2467,7 +2499,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerByIndex\",\n    \"params\": {\n        \"index\":0,\n        \"encoding\":\"cb58\"\n    }\n}",
+									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerByIndex\",\n    \"params\": {\n        \"index\":0,\n        \"encoding\":\"hex\"\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -2488,7 +2520,39 @@
 										"vtx"
 									]
 								},
-								"description": "Get container by index. The first container accepted is at index 0, the second is at index 1, etc. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index-getcontainerbyindex)"
+								"description": "Get container by index. The first container accepted is at index 0, the second is at index 1, etc. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getcontainerbyindex)"
+							},
+							"response": []
+						},
+						{
+							"name": "getContainerByID",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerByID\",\n    \"params\": {\n        \"containerID\":\"8JeLjRDCojGAZXYNvLDxeU7XhKaTiMzJsSEue7d37kA1n1Htm\",\n        \"encoding\":\"hex\"\n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{protocol}}://{{host}}:{{port}}/ext/index/X/vtx",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"ext",
+										"index",
+										"X",
+										"vtx"
+									]
+								},
+								"description": "Get container by ID. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getcontainerbyid)"
 							},
 							"response": []
 						},
@@ -2499,7 +2563,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerRange\",\n    \"params\": {\n        \"startIndex\":0,\n        \"numtoFetch\":10,\n        \"encoding\":\"cb58\"\n    }\n}",
+									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerRange\",\n    \"params\": {\n        \"startIndex\":0,\n        \"numtoFetch\":10,\n        \"encoding\":\"hex\"\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -2520,7 +2584,7 @@
 										"vtx"
 									]
 								},
-								"description": "Returns containers with indices in [startIndex, startIndex+1, ... , startIndex + numToFetch - 1]. numToFetch must be in \\[0,1024\\] [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index-getcontainerrange)"
+								"description": "Returns containers with indices in [startIndex, startIndex+1, ... , startIndex + numToFetch - 1]. numToFetch must be in \\[0,1024\\] [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getcontainerrange)"
 							},
 							"response": []
 						},
@@ -2531,7 +2595,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getIndex\",\n    \"params\": {\n        \"containerID\":\"6fXf5hncR8LXvwtM8iezFQBpK5cubV6y1dWgpJCcNyzGB1EzY\",\n        \"encoding\":\"cb58\"\n    }\n}",
+									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getIndex\",\n    \"params\": {\n        \"containerID\":\"kLBLyNrBr9rjHFBScjvogspz167wrTD47SqbTsLk6YGGnjHwZ\",\n        \"encoding\":\"hex\"\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -2552,7 +2616,7 @@
 										"vtx"
 									]
 								},
-								"description": "Get a container's index. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index-getindex)"
+								"description": "Get a container's index. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getindex)"
 							},
 							"response": []
 						},
@@ -2563,7 +2627,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.isAccepted\",\n    \"params\": {\n        \"containerID\":\"6fXf5hncR8LXvwtM8iezFQBpK5cubV6y1dWgpJCcNyzGB1EzY\",\n        \"encoding\":\"cb58\"\n    }\n}",
+									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.isAccepted\",\n    \"params\": {\n        \"containerID\":\"kLBLyNrBr9rjHFBScjvogspz167wrTD47SqbTsLk6YGGnjHwZ\",\n        \"encoding\":\"hex\"\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -2584,7 +2648,7 @@
 										"vtx"
 									]
 								},
-								"description": "Returns true if the container is in this index. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index-isaccepted)"
+								"description": "Returns true if the container is in this index. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.isaccepted)"
 							},
 							"response": []
 						}
@@ -2600,7 +2664,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getLastAccepted\",\n    \"params\": {\n        \"encoding\":\"cb58\"\n    }\n}",
+									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getLastAccepted\",\n    \"params\": {\n        \"encoding\":\"hex\"\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -2621,7 +2685,7 @@
 										"block"
 									]
 								},
-								"description": "Get the most recently accepted container. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index-getlastaccepted)"
+								"description": "Get the most recently accepted container. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getlastaccepted)"
 							},
 							"response": []
 						},
@@ -2632,7 +2696,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerByIndex\",\n    \"params\": {\n        \"index\":0,\n        \"encoding\":\"cb58\"\n    }\n}",
+									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerByIndex\",\n    \"params\": {\n        \"index\":0,\n        \"encoding\":\"hex\"\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -2653,7 +2717,39 @@
 										"block"
 									]
 								},
-								"description": "Get container by index. The first container accepted is at index 0, the second is at index 1, etc. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index-getcontainerbyindex)"
+								"description": "Get container by index. The first container accepted is at index 0, the second is at index 1, etc. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getcontainerbyindex)"
+							},
+							"response": []
+						},
+						{
+							"name": "getContainerByIndex Copy",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerByID\",\n    \"params\": {\n        \"containerID\":\"8JeLjRDCojGAZXYNvLDxeU7XhKaTiMzJsSEue7d37kA1n1Htm\",\n        \"encoding\":\"hex\"\n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{protocol}}://{{host}}:{{port}}/ext/index/P/block",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"ext",
+										"index",
+										"P",
+										"block"
+									]
+								},
+								"description": "Get container by ID. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getcontainerbyid)"
 							},
 							"response": []
 						},
@@ -2664,7 +2760,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerRange\",\n    \"params\": {\n        \"startIndex\":0,\n        \"numtoFetch\":10,\n        \"encoding\":\"cb58\"\n    }\n}",
+									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerRange\",\n    \"params\": {\n        \"startIndex\":0,\n        \"numtoFetch\":10,\n        \"encoding\":\"hex\"\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -2685,7 +2781,7 @@
 										"block"
 									]
 								},
-								"description": "Returns containers with indices in [startIndex, startIndex+1, ... , startIndex + numToFetch - 1]. numToFetch must be in \\[0,1024\\] [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index-getcontainerrange)"
+								"description": "Returns containers with indices in [startIndex, startIndex+1, ... , startIndex + numToFetch - 1]. numToFetch must be in \\[0,1024\\] [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getcontainerrange)"
 							},
 							"response": []
 						},
@@ -2696,7 +2792,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getIndex\",\n    \"params\": {\n        \"containerID\":\"4AqeFPxtTW4B5D6oR8gRZTvRKnnqkUWiV6mUNZxjUMbQKYWpi\",\n        \"encoding\":\"cb58\"\n    }\n}",
+									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getIndex\",\n    \"params\": {\n        \"containerID\":\"4AqeFPxtTW4B5D6oR8gRZTvRKnnqkUWiV6mUNZxjUMbQKYWpi\",\n        \"encoding\":\"hex\"\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -2717,7 +2813,7 @@
 										"block"
 									]
 								},
-								"description": "Get a container's index. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index-getindex)"
+								"description": "Get a container's index. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getindex)"
 							},
 							"response": []
 						},
@@ -2728,7 +2824,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.isAccepted\",\n    \"params\": {\n        \"containerID\":\"4AqeFPxtTW4B5D6oR8gRZTvRKnnqkUWiV6mUNZxjUMbQKYWpi\",\n        \"encoding\":\"cb58\"\n    }\n}",
+									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.isAccepted\",\n    \"params\": {\n        \"containerID\":\"4AqeFPxtTW4B5D6oR8gRZTvRKnnqkUWiV6mUNZxjUMbQKYWpi\",\n        \"encoding\":\"hex\"\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -2749,7 +2845,7 @@
 										"block"
 									]
 								},
-								"description": "Returns true if the container is in this index. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index-isaccepted)"
+								"description": "Returns true if the container is in this index. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.isaccepted)"
 							},
 							"response": []
 						}
@@ -2765,7 +2861,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getLastAccepted\",\n    \"params\": {\n        \"encoding\":\"cb58\"\n    }\n}",
+									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getLastAccepted\",\n    \"params\": {\n        \"encoding\":\"hex\"\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -2786,7 +2882,7 @@
 										"block"
 									]
 								},
-								"description": "Get the most recently accepted container. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index-getlastaccepted)"
+								"description": "Get the most recently accepted container. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getlastaccepted)"
 							},
 							"response": []
 						},
@@ -2797,7 +2893,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerByIndex\",\n    \"params\": {\n        \"index\":0,\n        \"encoding\":\"cb58\"\n    }\n}",
+									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerByIndex\",\n    \"params\": {\n        \"index\":0,\n        \"encoding\":\"hex\"\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -2818,7 +2914,39 @@
 										"block"
 									]
 								},
-								"description": "Get container by index. The first container accepted is at index 0, the second is at index 1, etc. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index-getcontainerbyindex)"
+								"description": "Get container by index. The first container accepted is at index 0, the second is at index 1, etc. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getcontainerbyindex)"
+							},
+							"response": []
+						},
+						{
+							"name": "getContainerByID",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerByID\",\n    \"params\": {\n        \"containerID\":\"8JeLjRDCojGAZXYNvLDxeU7XhKaTiMzJsSEue7d37kA1n1Htm\",\n        \"encoding\":\"hex\"\n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{protocol}}://{{host}}:{{port}}/ext/index/C/block",
+									"protocol": "{{protocol}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"ext",
+										"index",
+										"C",
+										"block"
+									]
+								},
+								"description": "Get container by ID. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getcontainerbyid)"
 							},
 							"response": []
 						},
@@ -2829,7 +2957,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerRange\",\n    \"params\": {\n        \"startIndex\":0,\n        \"numtoFetch\":10,\n        \"encoding\":\"cb58\"\n    }\n}",
+									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerRange\",\n    \"params\": {\n        \"startIndex\":0,\n        \"numtoFetch\":10,\n        \"encoding\":\"hex\"\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -2850,7 +2978,7 @@
 										"block"
 									]
 								},
-								"description": "Returns containers with indices in [startIndex, startIndex+1, ... , startIndex + numToFetch - 1]. numToFetch must be in \\[0,1024\\] [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index-getcontainerrange)"
+								"description": "Returns containers with indices in [startIndex, startIndex+1, ... , startIndex + numToFetch - 1]. numToFetch must be in \\[0,1024\\] [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getcontainerrange)"
 							},
 							"response": []
 						},
@@ -2861,7 +2989,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getIndex\",\n    \"params\": {\n        \"containerID\":\"4AqeFPxtTW4B5D6oR8gRZTvRKnnqkUWiV6mUNZxjUMbQKYWpi\",\n        \"encoding\":\"cb58\"\n    }\n}",
+									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getIndex\",\n    \"params\": {\n        \"containerID\":\"4AqeFPxtTW4B5D6oR8gRZTvRKnnqkUWiV6mUNZxjUMbQKYWpi\",\n        \"encoding\":\"hex\"\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -2882,7 +3010,7 @@
 										"block"
 									]
 								},
-								"description": "Get a container's index. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index-getindex)"
+								"description": "Get a container's index. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.getindex)"
 							},
 							"response": []
 						},
@@ -2893,7 +3021,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.isAccepted\",\n    \"params\": {\n        \"containerID\":\"4AqeFPxtTW4B5D6oR8gRZTvRKnnqkUWiV6mUNZxjUMbQKYWpi\",\n        \"encoding\":\"cb58\"\n    }\n}",
+									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.isAccepted\",\n    \"params\": {\n        \"containerID\":\"4AqeFPxtTW4B5D6oR8gRZTvRKnnqkUWiV6mUNZxjUMbQKYWpi\",\n        \"encoding\":\"hex\"\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -2914,7 +3042,7 @@
 										"block"
 									]
 								},
-								"description": "Returns true if the container is in this index. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index-isaccepted)"
+								"description": "Returns true if the container is in this index. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index.isaccepted)"
 							},
 							"response": []
 						}
@@ -3335,7 +3463,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"id\": 1,\n    \"method\": \"keystore.exportUser\",\n    \"params\": {\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    }\n}",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"id\": 1,\n    \"method\": \"keystore.exportUser\",\n    \"params\": {\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\",\n        \"encoding\": \"hex\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -3365,7 +3493,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"keystore.importUser\",\n    \"params\" :{\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\",\n        \"user\"    :\"21fDEsBk5U3FkquFGYpNdn3G9Ctr8BhW5wPVDuJqR86rEKKminsx8VvNFL4dKu6m6YjmJvwDA6f3a32d9F1qnTCkhD4Fw1URX3Cmz3GD3buzZp316dacYzx7gcEs2khxcaoGBudbcg3wiKJvbQhJS4Lcc5HZxEuMZtgNrgJgTBeoZrSpVgqafadQiUYTVycHmabFdduBS2C628v71Gx6gCMRYg15wxvg5jbLjF8xvijMDgdw29bf7aHkp5MT69mnj4pNr7VoKgquktCbu9tK2uX1PWea8kDDXzKaYwYC4tVVpGefX9qVvLf8eFaudkLiKdMM2FbedyUzQo9zS5cEJDLwH9EtANdqnp5kHqTRVeGebVsGXaVf7LMfQg4DZAGSk5C8qrDUdqkKH7MY9UW19DguKCY8jERkK2wauzKdHw4kMmYBA5SVMbjn88i61rq7iUHUuGis9927ihBS1\"\n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"keystore.importUser\",\n    \"params\" :{\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\",\n        \"user\"    :\"0x0000b79e54bb3452985874844fd02ce47671725850111b14d5b06d4b3e142ec852b39d1be2bdead684977bc0a1bfa6eeb06e000000040000004066687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f292500000000000000000000000000000000000000000000000000000000000000000000004c00000000002a92a15386259d71410fe602a9a1e2207a7afae3efd8d86f142577405476e5337a0736ba095b0fe911cb3100000018226dc5aec589008bc87ce142d5488d942f7e9d37374be99f0000003466687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f29253cb7d3842e8cee6a0ebd09f1fe884f6861e1b29c00000052000000000030b46ad90c1ef2f22282a9ab9c045cf190506148a7afcf4e94360e7e4109ef9abbc4aa97dd84533a5b081c0da489e205f00000001825e30947b222849b4f69b0a1eaf1dd49c82f5b64995d3c4e00000040faa57ee922f01eb75ca224d2e8aaf9cb60973d011e0ac08c7b3798c3aacf79de00000000000000000000000000000000000000000000000000000000000000000000004c00000000002a098545758bbf938acd508762ffff24bd2e8e0f80313fb0957c51fea30df6f304a94568c30dfb06257deb00000018e722d87e7d5964aa8a8772b0985d0723d398681ef29fad7900000034faa57ee922f01eb75ca224d2e8aaf9cb60973d011e0ac08c7b3798c3aacf79de3cb7d3842e8cee6a0ebd09f1fe884f6861e1b29c00000052000000000030722156f457680f16cf010d7cb3b350aaf210ae9ed58aaf89017f0046c5380ddf76fb944a6ff9a287a6a6e6c6303c751a000000183edfb66b8b01e6197507cde7e4909f816d3accf753155f96b346b48c\",\n        \"encoding\": \"hex\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -3896,7 +4024,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getRewardUTXOs\",\n    \"params\" :{\n        \"txID\":\"2nmH8LithVbdjaXsxVQCQfXtzN9hBbmebrsaEYnLM9T32Uy2Y4\"\n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getRewardUTXOs\",\n    \"params\" :{\n        \"txID\":\"2nmH8LithVbdjaXsxVQCQfXtzN9hBbmebrsaEYnLM9T32Uy2Y4\",\n        \"encoding\": \"hex\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -3927,7 +4055,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getStake\",\n    \"params\": {\n        \"addresses\": [\"{{pchainAddress}}\"]\n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getStake\",\n    \"params\": {\n        \"addresses\": [\"{{pchainAddress}}\"],\n        \"encoding\": \"hex\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -4082,7 +4210,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getTx\",\n    \"params\" :{\n        \"txID\":\"Cy7cZUot6DCUUDz1VuA2C7vFVWSzW3DgLhYXUAiLWH8BKafbH\",\n        \"encoding\": \"cb58\"\n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getTx\",\n    \"params\" :{\n        \"txID\":\"Cy7cZUot6DCUUDz1VuA2C7vFVWSzW3DgLhYXUAiLWH8BKafbH\",\n        \"encoding\": \"hex\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -4144,7 +4272,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getUTXOs\",\n    \"params\" :{\n        \"addresses\":[\"P-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u\"],\n        \"sourceChain\": \"X\",\n        \"limit\": 5\n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getUTXOs\",\n    \"params\" :{\n        \"addresses\":[\"P-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u\"],\n        \"sourceChain\": \"X\",\n        \"limit\": 5,\n        \"encoding\": \"hex\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -4330,7 +4458,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.issueTx\",\n    \"params\": {\n        \"tx\":\"111Bit5JNASbJyTLrd2kWkYRoc96swEWoWdmEhuGAFK3rCAyTnTzomuFwgx1SCUdUE71KbtXPnqj93KGr3CeftpPN37kVyqBaAQ5xaDjr7wVBTUYi9iV7kYJnHF61yovViJF74mJJy7WWQKeRMDRTiPuii5gsd11gtNahCCsKbm9seJtk2h1wAPZn9M1eL84CGVPnLUiLP\"\n    },\n    \"id\": 1\n}",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.issueTx\",\n    \"params\": {\n        \"tx\":\"0x00\",\n        \"encoding\": \"hex\"\n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"

--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -327,7 +327,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"id\"     : 1,\n    \"method\" : \"avm.buildGenesis\",\n    \"params\" : {\n        \"genesisData\": {\n            \"asset1\": {\n                \"name\": \"asset1\",\n                \"symbol\":\"MFCA\",\n                \"memo\": \"2Zc54v4ek37TEwu4LiV3j41PUMRd6acDDU3ZCVSxE7X\",\n                \"denomination\": 1, \n                \"initialState\": {\n                    \"fixedCap\" : [\n                        {\n                            \"amount\":100000,\n                            \"address\": \"local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u\"\n                        }\n                    ]\n                }\n            },\n            \"asset2\": {\n                \"name\": \"asset2\",\n                \"symbol\":\"MVCA\",\n                \"memo\": \"2Zc54v4ek37TEwu4LiV3j41PUMRd6acDDU3ZCVSxE7X\",\n                \"denomination\": 2, \n                \"initialState\": {\n                    \"variableCap\" : [\n                        {\n                            \"amount\":100000,\n                            \"address\": \"local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u\"\n                        }\n                    ]\n                }\n            }\n        },\n        \"networkId\": 12345\n    }\n}",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"id\"     : 1,\n    \"method\" : \"avm.buildGenesis\",\n    \"params\" : {\n        \"genesisData\": {\n            \"asset1\": {\n                \"name\": \"asset1\",\n                \"symbol\":\"MFCA\",\n                \"memo\": \"2Zc54v4ek37TEwu4LiV3j41PUMRd6acDDU3ZCVSxE7X\",\n                \"denomination\": 1, \n                \"initialState\": {\n                    \"fixedCap\" : [\n                        {\n                            \"amount\":100000,\n                            \"address\": \"local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u\"\n                        }\n                    ]\n                }\n            },\n            \"asset2\": {\n                \"name\": \"asset2\",\n                \"symbol\":\"MVCA\",\n                \"memo\": \"2Zc54v4ek37TEwu4LiV3j41PUMRd6acDDU3ZCVSxE7X\",\n                \"denomination\": 2, \n                \"initialState\": {\n                    \"variableCap\" : [\n                        {\n                            \"amount\":100000,\n                            \"address\": \"local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u\"\n                        }\n                    ]\n                }\n            }\n        },\n        \"networkId\": 12345\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1040,7 +1040,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.send\",\n    \"params\" :{ \n        \"assetID\" : \"{{avaxAssetId}}\",\n        \"amount\"  : 2000000,\n        \"from\"    : [\"{{xchainAddress}}\"],\n        \"to\"      : \"{{xchainAddress}}\",\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"memo\"    : \"{{memo}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\" \n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.send\",\n    \"params\" :{ \n        \"assetID\" : \"{{avaxAssetId}}\",\n        \"amount\"  : 2000000000,\n        \"from\"    : [\"{{xchainAddress}}\"],\n        \"to\"      : \"X-local1q8ayy4dxap07fvm3k8fydgsac3wt4eh933pmt6\",\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"memo\"    : \"\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\" \n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1195,38 +1195,38 @@
 			"name": "EVM",
 			"item": [
 				{
-          "name": "eth_baseFee",
-          "request": {
-            "method": "POST",
-            "header": [],
-            "body": {
-              "mode": "raw",
-              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_baseFee\",\n    \"params\": [],\n    \"id\": 1\n}",
-              "options": {
-                "raw": {
-                  "language": "json"
-                }
-              }
-            },
-            "url": {
-              "raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/rpc",
-              "protocol": "{{protocol}}",
-              "host": [
-                "{{host}}"
-              ],
-              "port": "{{port}}",
-              "path": [
-                "ext",
-                "bc",
-                "C",
-                "rpc"
-              ]
-            },
-            "description": "Get the base fee for the next block. [More info](https://docs.avax.network/build/apis/contract-chain-c-chain-api#eth_baseFee)"
-          },
-          "response": []
-        },
-        {
+					"name": "eth_baseFee",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_baseFee\",\n    \"params\": [],\n    \"id\": 1\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/rpc",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"bc",
+								"C",
+								"rpc"
+							]
+						},
+						"description": "Get the base fee for the next block. [More info](https://docs.avax.network/build/apis/contract-chain-c-chain-api#eth_baseFee)"
+					},
+					"response": []
+				},
+				{
 					"name": "eth_blockNumber",
 					"request": {
 						"method": "POST",
@@ -1387,38 +1387,38 @@
 					"response": []
 				},
 				{
-          "name": "eth_maxPriorityFeePerGas",
-          "request": {
-            "method": "POST",
-            "header": [],
-            "body": {
-              "mode": "raw",
-              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_maxPriorityFeePerGas\",\n    \"params\": [],\n    \"id\": 1\n}",
-              "options": {
-                "raw": {
-                  "language": "json"
-                }
-              }
-            },
-            "url": {
-              "raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/rpc",
-              "protocol": "{{protocol}}",
-              "host": [
-                "{{host}}"
-              ],
-              "port": "{{port}}",
-              "path": [
-                "ext",
-                "bc",
-                "C",
-                "rpc"
-              ]
-            },
-            "description": "Get the priority fee needed to be included in a block. [More info](https://docs.avax.network/build/apis/contract-chain-c-chain-api#eth_maxPriorityFeePerGas)"
-          },
-          "response": []
-        },
-        {
+					"name": "eth_maxPriorityFeePerGas",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_maxPriorityFeePerGas\",\n    \"params\": [],\n    \"id\": 1\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/C/rpc",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"bc",
+								"C",
+								"rpc"
+							]
+						},
+						"description": "Get the priority fee needed to be included in a block. [More info](https://docs.avax.network/build/apis/contract-chain-c-chain-api#eth_maxPriorityFeePerGas)"
+					},
+					"response": []
+				},
+				{
 					"name": "eth_signTransaction",
 					"request": {
 						"method": "POST",
@@ -3524,7 +3524,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-              "raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.addSubnetValidator\",\n    \"params\": {\n        \"nodeID\":\"{{avalancheNodeId}}\",\n        \"subnetID\":\"{{avalancheSubnetId}}\",\n        \"startTime\":1625782598,\n        \"endTime\":1627078419,\n        \"weight\":20,\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.addSubnetValidator\",\n    \"params\": {\n        \"nodeID\":\"{{avalancheNodeId}}\",\n        \"subnetID\":\"{{avalancheSubnetId}}\",\n        \"startTime\":1625782598,\n        \"endTime\":1627078419,\n        \"weight\":20,\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -3703,7 +3703,38 @@
 					},
 					"response": []
 				},
-        {
+				{
+					"name": "timestamp",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.getBlockchains\",\n    \"params\": {},\n    \"id\": 1\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"bc",
+								"P"
+							]
+						},
+						"description": "Get all the blockchains that exist (excluding the P-Chain). [More info](https://docs.avax.network/v1.0/en/api/platform/#platformgetblockchains)"
+					},
+					"response": []
+				},
+				{
 					"name": "getBlockchainStatus",
 					"request": {
 						"method": "POST",
@@ -4134,6 +4165,37 @@
 							]
 						},
 						"description": "Get the UTXOs that reference a given address. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmgetutxos)"
+					},
+					"response": []
+				},
+				{
+					"name": "getValidatorsAt",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getValidatorsAt\",\n    \"params\" :{\n        \"height\": 0,\n        \"subnetID\": \"11111111111111111111111111111111LpoYY\"\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"bc",
+								"P"
+							]
+						},
+						"description": "Get the validators and their weights of a subnet or the Primary Network at a given P-Chain height. [More info](https://docs.avax.network/build/avalanchego-apis/platform-chain-p-chain-api#platform-getvalidatorsat)"
 					},
 					"response": []
 				},

--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -1672,6 +1672,36 @@
 					"response": []
 				},
 				{
+					"name": "getMinStake",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"info.getTxFee\",\n    \"params\": {\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{http}}://{{host}}:{{port}}/ext/info",
+							"protocol": "{{http}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"info"
+							]
+						},
+						"description": "Get the minimum staking amount of the network. [More info](https://docs.avax.network/v1.0/en/api/info/#infogetminstake)"
+					},
+					"response": []
+				},
+				{
 					"name": "getNetworkID",
 					"request": {
 						"method": "POST",
@@ -1792,6 +1822,36 @@
 					"response": []
 				},
 				{
+					"name": "getTxFee",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"info.getTxFee\",\n    \"params\": {\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{http}}://{{host}}:{{port}}/ext/info",
+							"protocol": "{{http}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"info"
+							]
+						},
+						"description": "Get the transaction fee of the network. [More info](https://docs.avax.network/v1.0/en/api/info/#infogettxfee)"
+					},
+					"response": []
+				},
+				{
 					"name": "peers",
 					"request": {
 						"method": "POST",
@@ -1818,39 +1878,6 @@
 							]
 						},
 						"description": "Get description of peer connections. [More info](https://docs.avax.network/v1.0/en/api/info/#infopeers)"
-					},
-					"response": []
-				},
-				{
-					"name": "isBootstrapped",
-					"protocolProfileBehavior": {
-						"disabledSystemHeaders": {}
-					},
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\r\n    \"jsonrpc\":\"2.0\",\r\n    \"id\"     :1,\r\n    \"method\" :\"info.isBootstrapped\",\r\n    \"params\": {\r\n        \"chain\":\"X\"\r\n    }\r\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/info",
-							"protocol": "{{http}}",
-							"host": [
-								"{{host}}"
-							],
-							"port": "{{port}}",
-							"path": [
-								"ext",
-								"info"
-							]
-						},
-						"description": "Checks whether the chain is done boostrapping. Use \"chain\" parameter to select which chain to query, can be one of \"X\", \"P\" or \"C\"."
 					},
 					"response": []
 				}
@@ -2563,6 +2590,7 @@
 							"port": "{{port}}",
 							"path": [
 								"ext",
+								"bc",
 								"P"
 							]
 						},

--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -33,7 +33,7 @@
 								"admin"
 							]
 						},
-						"description": "Assign an API an alias, a different endpoint for the API. The original endpoint will still work. This change only affects this node; other nodes will not know about this alias. [More info](https://docs.avax.network/build/apis/admin-api#admin-alias)"
+						"description": "Assign an API an alias, a different endpoint for the API. The original endpoint will still work. This change only affects this node; other nodes will not know about this alias. [More info](https://docs.avax.network/apis/avalanchego/apis/admin#adminalias)"
 					},
 					"response": []
 				},
@@ -61,7 +61,7 @@
 								"admin"
 							]
 						},
-						"description": "Give a blockchain an alias, a different name that can be used any place the blockchain’s ID is used. [More info](https://docs.avax.network/build/apis/admin-api#admin-aliaschain)"
+						"description": "Give a blockchain an alias, a different name that can be used any place the blockchain’s ID is used. [More info](https://docs.avax.network/apis/avalanchego/apis/admin#adminaliaschain)"
 					},
 					"response": []
 				},
@@ -89,7 +89,7 @@
 								"admin"
 							]
 						},
-						"description": "Dump the mutex statistics of the node to the specified file. [More info](https://docs.avax.network/build/apis/admin-api#admin-lockprofile)"
+						"description": "Dump the mutex statistics of the node to the specified file. [More info](https://docs.avax.network/apis/avalanchego/apis/admin#admingetchainaliases)"
 					},
 					"response": []
 				},
@@ -117,7 +117,7 @@
 								"admin"
 							]
 						},
-						"description": "Returns log and display levels of loggers. [More info](https://docs.avax.network/build/avalanchego-apis/admin#admingetloggerlevel)"
+						"description": "Returns log and display levels of loggers. [More info](https://docs.avax.network/apis/avalanchego/apis/admin#admingetloggerlevel)"
 					},
 					"response": []
 				},
@@ -173,7 +173,7 @@
 								"admin"
 							]
 						},
-						"description": "Dump the mutex statistics of the node to the specified file. [More info](https://docs.avax.network/build/apis/admin-api#admin-lockprofile)"
+						"description": "Dump the mutex statistics of the node to the specified file. [More info](https://docs.avax.network/apis/avalanchego/apis/admin#adminlockprofile)"
 					},
 					"response": []
 				},
@@ -201,7 +201,7 @@
 								"admin"
 							]
 						},
-						"description": "Dump the mutex statistics of the node to the specified file. [More info](https://docs.avax.network/build/apis/admin-api#admin-memoryprofile)"
+						"description": "Dump the mutex statistics of the node to the specified file. [More info](https://docs.avax.network/apis/avalanchego/apis/admin#adminmemoryprofile)"
 					},
 					"response": []
 				},
@@ -229,7 +229,7 @@
 								"admin"
 							]
 						},
-						"description": "Sets log and display levels of loggers. [More info](https://docs.avax.network/build/avalanchego-apis/admin#adminsetloggerlevel)"
+						"description": "Sets log and display levels of loggers. [More info](https://docs.avax.network/apis/avalanchego/apis/admin#adminsetloggerlevel)"
 					},
 					"response": []
 				},
@@ -257,7 +257,7 @@
 								"admin"
 							]
 						},
-						"description": "Start profiling the CPU utilization of the node. Will write the profile to the specified file on stop. [More info](https://docs.avax.network/build/apis/admin-api#admin-startcpuprofiler)"
+						"description": "Start profiling the CPU utilization of the node. Will write the profile to the specified file on stop. [More info](https://docs.avax.network/apis/avalanchego/apis/admin#adminstartcpuprofiler)"
 					},
 					"response": []
 				},
@@ -285,7 +285,7 @@
 								"admin"
 							]
 						},
-						"description": "Stop the CPU profile that was previously started. [More info](https://docs.avax.network/build/apis/admin-api#admin-stopcpuprofiler)"
+						"description": "Stop the CPU profile that was previously started. [More info](https://docs.avax.network/apis/avalanchego/apis/admin#adminstopcpuprofiler)"
 					},
 					"response": []
 				}
@@ -319,7 +319,7 @@
 								"auth"
 							]
 						},
-						"description": "Creates a new authorization token that grants access to one or more API endpoints.\n [More info](https://docs.avax.network/build/apis/auth-api#auth-newtoken)"
+						"description": "Creates a new authorization token that grants access to one or more API endpoints.  \n[More info](https://docs.avax.network/apis/avalanchego/apis/auth#authnewtoken)"
 					},
 					"response": []
 				},
@@ -347,7 +347,7 @@
 								"auth"
 							]
 						},
-						"description": "Revoke a previously generated token. The given token will no longer grant access to any endpoint.\nIf the token is invalid, does nothing. [More info](https://docs.avax.network/build/apis/auth-api#auth-revoketoken)"
+						"description": "Revoke a previously generated token. The given token will no longer grant access to any endpoint.  \nIf the token is invalid, does nothing. [More info](https://docs.avax.network/apis/avalanchego/apis/auth#authrevoketoken)"
 					},
 					"response": []
 				},
@@ -375,7 +375,7 @@
 								"auth"
 							]
 						},
-						"description": "Change this node's authorization token password. Any authorization tokens created under an old password will become invalid. [More info](https://docs.avax.network/build/apis/auth-api#auth-changepassword)"
+						"description": "Change this node's authorization token password. Any authorization tokens created under an old password will become invalid. [More info](https://docs.avax.network/apis/avalanchego/apis/auth#authchangepassword)"
 					},
 					"response": []
 				}
@@ -802,7 +802,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.getBlockByHeight\",\n    \"params\" :{\n        \"height\": {{height}},\n        \"encoding\": \"hex\"\n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.getBlockByHeight\",\n    \"params\" :{\n        \"height\": {{xhcainBlockHeight}},\n        \"encoding\": \"hex\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"

--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -45,7 +45,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"admin.aliasChain\",\n    \"params\": {\n        \"chain\":\"2VvmkRw4yrz8tPrVnCCbvEK1JxNyujpqhmU6SGonxMpkWBx9UD\",\n        \"alias\":\"myBlockchainAlias\"\n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"admin.aliasChain\",\n    \"params\": {\n        \"chain\":\"2VvmkRw4yrz8tPrVnCCbvEK1JxNyujpqhmU6SGonxMpkWBx9UD\",\n        \"alias\":\"myXChainAlias\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -823,7 +823,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.send\",\n    \"params\" :{ \n        \"assetID\" :\"AVA\",\n        \"amount\"  :10000,\n        \"to\"      :\"X-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u\",\n        \"username\":\"username\",\n        \"password\":\"password\"\n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.send\",\n    \"params\" :{ \n        \"assetID\" :\"AVAX\",\n        \"amount\"  :10000,\n        \"to\"      :\"X-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u\",\n        \"username\":\"username\",\n        \"password\":\"password\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -844,37 +844,6 @@
 							]
 						},
 						"description": "Send a quantity of an asset to an address. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmsend)"
-					},
-					"response": []
-				},
-				{
-					"name": "signMintTx",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.signMintTx\",\n    \"params\" :{\n        \"tx\":\"1112yKaDdTb7XZXqX38X8U6ro7EC4GQdxDU48eHTcoQxPtJncHSQEMCi9n3hYaPp33K95i8sntkox5ZMHNq26DeNui4yuSQANXgFEeondXZvq65Pk1jnXbUpkJPkjX4KG1W9XQMAmCNpXs5xHzpX4THcYg3WY569Rj7cdf9Km4FQ3r3VDUAn1dpZLsCyQHeGb8Lr3ub7PGh4pn42KPAWsS6N4xCAGg1GGww2XNBxoDfu81toejPJFuqTJQg6tzgL82uT3amebb4FYQVU5B2gxH5Amevm1zsiTTfNDWui4BfB6e7jt8fc36UWYgb4MiaaApmySUe4ndt7SjFTT6taDkVNFdbUWuNEfiebrYFLpqL86mQ1XD\",\n        \"minter\":\"X-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u\",\n        \"username\":\"userThatControlsTheSignerAddress\",\n        \"password\":\"passwordOfThatUser\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "http://localhost:9650/ext/bc/X",
-							"protocol": "http",
-							"host": [
-								"localhost"
-							],
-							"port": "9650",
-							"path": [
-								"ext",
-								"bc",
-								"X"
-							]
-						},
-						"description": "Sign an unsigned or partially signed transaction. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmsignminttx)"
 					},
 					"response": []
 				}
@@ -1990,7 +1959,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.addDefaultSubnetDelegator\",\n    \"params\": {\n        \"id\":\"7Xhw2mDxuDS44j42TCB6U5579esbSt3Lg\",\n        \"destination\":\"P-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u\",\n        \"startTime\":1595726193,\n        \"endTime\":1598317594,\n        \"stakeAmount\":54321,\n        \"username\": \"username\",\n        \"password\": \"password\"\n    },\n    \"id\": 1\n}",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.addDefaultSubnetDelegator\",\n    \"params\": {\n        \"nodeID\":\"NodeID-7Xhw2mDxuDS44j42TCB6U5579esbSt3Lg\",\n        \"rewardAddress\":\"P-local17g8d3p7hdyxdzss5vyeqry65q47av034e3vfd2\",\n        \"startTime\":1597773103,\n        \"endTime\":1600364505,\n        \"stakeAmount\":54321,\n        \"username\": \"username\",\n        \"password\": \"password\"\n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -2020,7 +1989,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.addDefaultSubnetValidator\",\n    \"params\": {\n        \"id\":\"ARCLrphAHZ28xZEBfUL7SVAmzkTZNe1LK\",\n        \"destination\":\"Q4MzFZZDPHRPAHFeDs3NiyyaZDvxHKivf\",\n        \"startTime\":1595050498,\n        \"endTime\":1597641900,\n        \"stakeAmount\":1000000,\n        \"delegationFeeRate\":100000\n    },\n    \"id\": 1\n}",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.addDefaultSubnetValidator\",\n    \"params\": {\n        \"nodeID\":\"NodeID-5mb46qkSBj81k9g9e4VFjGGSbaaSLFRzD\",\n        \"rewardAddress\":\"P-local17g8d3p7hdyxdzss5vyeqry65q47av034e3vfd2\",\n        \"startTime\":1597768339,\n        \"endTime\":1600359741,\n        \"stakeAmount\":2000000,\n        \"delegationFeeRate\":10,\n        \"username\": \"username\",\n        \"password\": \"password\"\n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -2374,6 +2343,68 @@
 					"response": []
 				},
 				{
+					"name": "getTx",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getTx\",\n    \"params\" :{\n        \"txID\":\"LK5gemsUXLQEuAjq37iGct2E5GC72KKLZxaVoDF7foQiSY6mu\"\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:9650/ext/bc/P",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9650",
+							"path": [
+								"ext",
+								"bc",
+								"P"
+							]
+						},
+						"description": "Returns the specified transaction [More info](https://docs.avax.network/v1.0/en/api/avm/#avmgetbalance)"
+					},
+					"response": []
+				},
+				{
+					"name": "getTxStatus",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getTxStatus\",\n    \"params\" :{\n        \"txID\":\"LK5gemsUXLQEuAjq37iGct2E5GC72KKLZxaVoDF7foQiSY6mu\"\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:9650/ext/bc/P",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9650",
+							"path": [
+								"ext",
+								"bc",
+								"P"
+							]
+						},
+						"description": "Returns the specified transaction [More info](https://docs.avax.network/v1.0/en/api/avm/#avmgetbalance)"
+					},
+					"response": []
+				},
+				{
 					"name": "exportAVAX",
 					"request": {
 						"method": "POST",
@@ -2410,7 +2441,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.exportKey\",\n    \"params\" :{\n        \"username\": \"username\",\n        \"password\": \"uYO0Mf6h!1\",\n        \"address\": \"P-local1k8jrjsqy574xv22s336pa2jv3pmyucc39zndkl\"\n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.exportKey\",\n    \"params\" :{\n        \"username\": \"username\",\n        \"password\": \"password\",\n        \"address\": \"P-local1k8jrjsqy574xv22s336pa2jv3pmyucc39zndkl\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -2440,7 +2471,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.importAVAX\",\n    \"params\": {\n        \"username\": \"username\",\n        \"password\": \"password\",\n        \"to\":\"P-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u\"\n    },\n    \"id\": 1\n}",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.importAVAX\",\n    \"params\": {\n        \"username\": \"username\",\n        \"password\": \"password\",\n        \"sourceChain\":\"X\",\n        \"to\":\"P-local17g8d3p7hdyxdzss5vyeqry65q47av034e3vfd2\"\n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -2580,36 +2611,6 @@
 							]
 						},
 						"description": "Sample validators from the specified Subnet. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformsamplevalidators)"
-					},
-					"response": []
-				},
-				{
-					"name": "sign",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.sign\",\n    \"params\": {\n        \"tx\":\"111Bit5JNASbJyTLrd2kWkYRoc96swEWoWdmEhuGAFK3rCAyTnTzomuFwgx1SCUdUE71KbtXPnqj93KGr3CeftpPN37kVyqBaAQ5xaDjr7wU8riGS89NDJ8AwVgZgnFkgF3uMfwCiCuPvvubGyQxNHE4TM9iDgj6h3URdGQ4JntP44wokCEP3ADn7sMM8kUTbmcNo84U87\",\n        \"signer\":\"P-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u\",\n        \"username\":\"username\",\n        \"password\":\"password\"\n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "http://localhost:9650/ext/P",
-							"protocol": "http",
-							"host": [
-								"localhost"
-							],
-							"port": "9650",
-							"path": [
-								"ext",
-								"P"
-							]
-						},
-						"description": "Sign an unsigned or partially signed transaction.\n\nTransactions to add non-default Subnets require signatures from control keys and from the account paying the transaction fee. If `signer` is a control key and the transaction needs more signatures from control keys, `sign` will provide a control signature. Otherwise, `signer` will sign to pay the transaction fee."
 					},
 					"response": []
 				},

--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -448,6 +448,37 @@
 					"response": []
 				},
 				{
+					"name": "export",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.export\",\n    \"params\" :{\n        \"to\":\"{{cchainbech32address}}\",\n        \"amount\": 50,\n        \"assetID\": \"2W4XDTMrQJm7YALcnCL4krU7JpoGQQaDkTdn2HbzpsqombHRaB\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/X",
+							"protocol": "{{http}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"bc",
+								"X"
+							]
+						},
+						"description": "Export AVAX from both the X-Chain to the P-Chain as well as from the X-Chain to the C-Chain.\nAfter calling this method, you must call either the P-Chain’s `importAVAX` method or the C-Chain's `importAVAX` method to complete the transfer. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmexportavax)"
+					},
+					"response": []
+				},
+				{
 					"name": "exportAVAX",
 					"request": {
 						"method": "POST",
@@ -723,6 +754,37 @@
 							]
 						},
 						"description": "Get the UTXOs that reference a given address. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmgetutxos)"
+					},
+					"response": []
+				},
+				{
+					"name": "import",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.import\",\n    \"params\" :{\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"sourceChain\": \"P\",\n        \"to\":\"{{xchainAddress}}\"\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/X",
+							"protocol": "{{http}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"bc",
+								"X"
+							]
+						},
+						"description": "Finalize a transfer of AVAX from either the P-Chain to the X-Chain or the C-Chain to the X-Chain.\n\nBefore this method is called, you must call either the P-Chain’s `exportAVAX` method or the C-Chain’s `exportAVAX` method to initiate the transfer. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmimportavax)"
 					},
 					"response": []
 				},
@@ -1109,6 +1171,38 @@
 					"response": []
 				},
 				{
+					"name": "eth_getAssetBalance",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_getAssetBalance\",\n    \"params\": [\n        \"{{cchainAddress}}\",\n        \"latest\",\n        \"2W4XDTMrQJm7YALcnCL4krU7JpoGQQaDkTdn2HbzpsqombHRaB\"\n    ],\n    \"id\": 1\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/rpc",
+							"protocol": "{{http}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"bc",
+								"C",
+								"rpc"
+							]
+						},
+						"description": "Getting an account’s balance. [More info](https://docs.avax.network/v1.0/en/api/evm/#getting-an-accounts-balance)"
+					},
+					"response": []
+				},
+				{
 					"name": "eth_getBalance",
 					"request": {
 						"method": "POST",
@@ -1365,6 +1459,38 @@
 					"response": []
 				},
 				{
+					"name": "export",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"method\" :\"avax.export\",\n    \"params\" :{\n        \"from\": [\"{{cchainAddress}}\"],\n        \"to\":\"{{xchainAddress}}\",\n        \"amount\": 25,\n        \"destinationChain\": \"X\",\n        \"changeAddr\": \"{{cchainAddress}}\",\n        \"assetID\": \"2W4XDTMrQJm7YALcnCL4krU7JpoGQQaDkTdn2HbzpsqombHRaB\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\"\n    },\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/avax",
+							"protocol": "{{http}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"bc",
+								"C",
+								"avax"
+							]
+						},
+						"description": "Send AVAX from the X-Chain to an account on the P-Chain.\nAfter calling this method, you must call the P-Chain’s `importAVAX` method to complete the transfer. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmexportavax)"
+					},
+					"response": []
+				},
+				{
 					"name": "exportAVAX",
 					"request": {
 						"method": "POST",
@@ -1429,6 +1555,38 @@
 					"response": []
 				},
 				{
+					"name": "import",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"method\": \"avax.import\",\n    \"params\": {\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"sourceChain\": \"X\",\n        \"to\":\"{{cchainAddress}}\"\n    },\n    \"jsonrpc\": \"2.0\",\n    \"id\": 1\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/avax",
+							"protocol": "{{http}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"bc",
+								"C",
+								"avax"
+							]
+						},
+						"description": "Send AVAX from the X-Chain to an account on the P-Chain.\nAfter calling this method, you must call the P-Chain’s `importAVAX` method to complete the transfer. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmexportavax)"
+					},
+					"response": []
+				},
+				{
 					"name": "importAVAX",
 					"request": {
 						"method": "POST",
@@ -1456,7 +1614,7 @@
 								"avax"
 							]
 						},
-						"description": "Send AVAX from the X-Chain to an account on the P-Chain.\nAfter calling this method, you must call the P-Chain’s `importAVAX` method to complete the transfer. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmexportavax)"
+						"description": "Import AVAX from the X-Chain to an account on the C-Chain.\nBefore calling this method, you must call the X-Chain’s `exportAVAX` method to initiate the transfer. [More info](https://docs.avax.network/v1.0/en/api/evm/#evmimportavax)"
 					},
 					"response": []
 				},

--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -361,7 +361,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.createFixedCapAsset\",\n    \"params\" :{\n        \"name\": \"Test Token\",\n        \"symbol\":\"TEST\",\n        \"initialHolders\": [\n            {\n                \"address\":\"{{xchainAddress}}\",\n                \"amount\":400\n            }\n        ],\n        \"from\": [\"{{xchainAddress}}\"],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.createFixedCapAsset\",\n    \"params\" :{\n        \"name\": \"Test Token\",\n        \"symbol\":\"TEST\",\n        \"denomination\": 0,  \n        \"initialHolders\": [\n            {\n                \"address\":\"{{xchainAddress}}\",\n                \"amount\":400\n            }\n        ],\n        \"from\": [\"{{xchainAddress}}\"],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -423,7 +423,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.createVariableCapAsset\",\n    \"params\" :{\n        \"name\":\"myVariableCapAsset\",\n        \"symbol\":\"MFCA\",\n        \"minterSets\":[\n            {\n                \"minters\":[\n                    \"{{xchainAddress}}\"\n                ],\n                \"threshold\": 1\n            }\n        ],\n        \"from\": [\"{{xchainAddress}}\"],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.createVariableCapAsset\",\n    \"params\" :{\n        \"name\":\"myVariableCapAsset\",\n        \"symbol\":\"MFCA\",\n        \"denomination\": 0,  \n        \"minterSets\":[\n            {\n                \"minters\":[\n                    \"{{xchainAddress}}\"\n                ],\n                \"threshold\": 1\n            }\n        ],\n        \"from\": [\"{{xchainAddress}}\"],\n        \"changeAddr\": \"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1403,7 +1403,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"method\" :\"avax.exportKey\",\n    \"params\" :{\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"address\": \"{{pchainAddress}}\"\n    },\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1\n}",
+							"raw": "{\n    \"method\" :\"avax.exportKey\",\n    \"params\" :{\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"address\": \"{{cchainAddress}}\"\n    },\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -2578,6 +2578,37 @@
 					"response": []
 				},
 				{
+					"name": "getCurrentSupply",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getCurrentSupply\",\n    \"params\": {}\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
+							"protocol": "{{http}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"bc",
+								"P"
+							]
+						},
+						"description": "Returns an upper bound on the number of AVAX that exist. This is an upper bound because it does not account for burnt tokens, including transaction fees. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformgetcurrentsupply)"
+					},
+					"response": []
+				},
+				{
 					"name": "getCurrentValidators",
 					"request": {
 						"method": "POST",
@@ -2760,6 +2791,37 @@
 							]
 						},
 						"description": "List the validators in the pending validator set of the specified Subnet. Each validator is not currently validating the Subnet but will in the future. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformgetpendingvalidators)"
+					},
+					"response": []
+				},
+				{
+					"name": "getStakingAssetID",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getStakingAssetID\",\n    \"params\": {}\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
+							"protocol": "{{http}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"bc",
+								"P"
+							]
+						},
+						"description": "Retrieve an assetID for a subnet’s staking asset. Currently this always returns the Primary Network’s staking assetID. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformgetstakingassetid)"
 					},
 					"response": []
 				},

--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -2605,6 +2605,36 @@
 					"response": []
 				},
 				{
+					"name": "getStake",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getStake\",\n    \"params\": {\n        \"addresses\": []\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{http}}://{{host}}:{{port}}/ext/P",
+							"protocol": "{{http}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"P"
+							]
+						},
+						"description": "Returns the staked amount for an array of addresses [More info](https://docs.avax.network/v1.0/en/api/platform/#platformgetstake)"
+					},
+					"response": []
+				},
+				{
 					"name": "getTxStatus",
 					"request": {
 						"method": "POST",

--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -474,7 +474,7 @@
 								"X"
 							]
 						},
-						"description": "Export AVAX from both the X-Chain to the P-Chain as well as from the X-Chain to the C-Chain.\nAfter calling this method, you must call either the P-Chain’s `importAVAX` method or the C-Chain's `importAVAX` method to complete the transfer. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmexportavax)"
+						"description": "Export a non-AVAX asset from the X-Chain to the C-Chain. After calling this method, you must call the C-Chain’s `import` method to complete the transfer. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmexport)"
 					},
 					"response": []
 				},
@@ -505,7 +505,7 @@
 								"X"
 							]
 						},
-						"description": "Export AVAX from both the X-Chain to the P-Chain as well as from the X-Chain to the C-Chain.\nAfter calling this method, you must call either the P-Chain’s `importAVAX` method or the C-Chain's `importAVAX` method to complete the transfer. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmexportavax)"
+						"description": "Export AVAX from the X-Chain to both the P-Chain as well as the C-Chain. After calling this method, you must call either the P-Chain’s `importAVAX` method or the C-Chain's `importAVAX` method to complete the transfer. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmexportavax)"
 					},
 					"response": []
 				},
@@ -1198,7 +1198,7 @@
 								"rpc"
 							]
 						},
-						"description": "Getting an account’s balance. [More info](https://docs.avax.network/v1.0/en/api/evm/#getting-an-accounts-balance)"
+						"description": "Getting an account’s non-AVAX balance. [More info](https://docs.avax.network/v1.0/en/api/evm/#getting-an-accounts-non-avax-balance)"
 					},
 					"response": []
 				},

--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "e337c02e-d072-4741-b24f-e38be44db4b7",
+		"_postman_id": "007a173c-071b-4df4-8914-368bfacf1d3f",
 		"name": "Avalanche",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -2194,6 +2194,672 @@
 			"description": "This API can be used for measuring node health. [More info](https://docs.avax.network/v1.0/en/api/health)"
 		},
 		{
+			"name": "Index",
+			"item": [
+				{
+					"name": "X-Chain Transactions",
+					"item": [
+						{
+							"name": "getLastAccepted",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getLastAccepted\",\n    \"params\": {\n        \"encoding\":\"cb58\"\n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{http}}://{{host}}:{{port}}/ext/index/X/tx",
+									"protocol": "{{http}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"ext",
+										"index",
+										"X",
+										"tx"
+									]
+								},
+								"description": "Get the most recently accepted container. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index-getlastaccepted)"
+							},
+							"response": []
+						},
+						{
+							"name": "getContainerByIndex",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerByIndex\",\n    \"params\": {\n        \"index\":0,\n        \"encoding\":\"cb58\"\n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{http}}://{{host}}:{{port}}/ext/index/X/tx",
+									"protocol": "{{http}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"ext",
+										"index",
+										"X",
+										"tx"
+									]
+								},
+								"description": "Get container by index. The first container accepted is at index 0, the second is at index 1, etc. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index-getcontainerbyindex)"
+							},
+							"response": []
+						},
+						{
+							"name": "getContainerRange",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerRange\",\n    \"params\": {\n        \"startIndex\":0,\n        \"numtoFetch\":10,\n        \"encoding\":\"cb58\"\n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{http}}://{{host}}:{{port}}/ext/index/X/tx",
+									"protocol": "{{http}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"ext",
+										"index",
+										"X",
+										"tx"
+									]
+								},
+								"description": "Returns containers with indices in [startIndex, startIndex+1, ... , startIndex + numToFetch - 1]. numToFetch must be in \\[0,1024\\] [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index-getcontainerrange)"
+							},
+							"response": []
+						},
+						{
+							"name": "getIndex",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getIndex\",\n    \"params\": {\n        \"containerID\":\"6fXf5hncR8LXvwtM8iezFQBpK5cubV6y1dWgpJCcNyzGB1EzY\",\n        \"encoding\":\"cb58\"\n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{http}}://{{host}}:{{port}}/ext/index/X/tx",
+									"protocol": "{{http}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"ext",
+										"index",
+										"X",
+										"tx"
+									]
+								},
+								"description": "Get a container's index. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index-getindex)"
+							},
+							"response": []
+						},
+						{
+							"name": "isAccepted",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.isAccepted\",\n    \"params\": {\n        \"containerID\":\"6fXf5hncR8LXvwtM8iezFQBpK5cubV6y1dWgpJCcNyzGB1EzY\",\n        \"encoding\":\"cb58\"\n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{http}}://{{host}}:{{port}}/ext/index/X/tx",
+									"protocol": "{{http}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"ext",
+										"index",
+										"X",
+										"tx"
+									]
+								},
+								"description": "Returns true if the container is in this index. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index-isaccepted)"
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "X-Chain Vertices",
+					"item": [
+						{
+							"name": "getLastAccepted",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getLastAccepted\",\n    \"params\": {\n        \"encoding\":\"cb58\"\n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{http}}://{{host}}:{{port}}/ext/index/X/vtx",
+									"protocol": "{{http}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"ext",
+										"index",
+										"X",
+										"vtx"
+									]
+								},
+								"description": "Get the most recently accepted container. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index-getlastaccepted)"
+							},
+							"response": []
+						},
+						{
+							"name": "getContainerByIndex",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerByIndex\",\n    \"params\": {\n        \"index\":0,\n        \"encoding\":\"cb58\"\n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{http}}://{{host}}:{{port}}/ext/index/X/vtx",
+									"protocol": "{{http}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"ext",
+										"index",
+										"X",
+										"vtx"
+									]
+								},
+								"description": "Get container by index. The first container accepted is at index 0, the second is at index 1, etc. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index-getcontainerbyindex)"
+							},
+							"response": []
+						},
+						{
+							"name": "getContainerRange",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerRange\",\n    \"params\": {\n        \"startIndex\":0,\n        \"numtoFetch\":10,\n        \"encoding\":\"cb58\"\n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{http}}://{{host}}:{{port}}/ext/index/X/vtx",
+									"protocol": "{{http}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"ext",
+										"index",
+										"X",
+										"vtx"
+									]
+								},
+								"description": "Returns containers with indices in [startIndex, startIndex+1, ... , startIndex + numToFetch - 1]. numToFetch must be in \\[0,1024\\] [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index-getcontainerrange)"
+							},
+							"response": []
+						},
+						{
+							"name": "getIndex",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getIndex\",\n    \"params\": {\n        \"containerID\":\"6fXf5hncR8LXvwtM8iezFQBpK5cubV6y1dWgpJCcNyzGB1EzY\",\n        \"encoding\":\"cb58\"\n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{http}}://{{host}}:{{port}}/ext/index/X/vtx",
+									"protocol": "{{http}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"ext",
+										"index",
+										"X",
+										"vtx"
+									]
+								},
+								"description": "Get a container's index. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index-getindex)"
+							},
+							"response": []
+						},
+						{
+							"name": "isAccepted",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.isAccepted\",\n    \"params\": {\n        \"containerID\":\"6fXf5hncR8LXvwtM8iezFQBpK5cubV6y1dWgpJCcNyzGB1EzY\",\n        \"encoding\":\"cb58\"\n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{http}}://{{host}}:{{port}}/ext/index/X/vtx",
+									"protocol": "{{http}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"ext",
+										"index",
+										"X",
+										"vtx"
+									]
+								},
+								"description": "Returns true if the container is in this index. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index-isaccepted)"
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "P-Chain Blocks",
+					"item": [
+						{
+							"name": "getLastAccepted",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getLastAccepted\",\n    \"params\": {\n        \"encoding\":\"cb58\"\n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{http}}://{{host}}:{{port}}/ext/index/P/block",
+									"protocol": "{{http}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"ext",
+										"index",
+										"P",
+										"block"
+									]
+								},
+								"description": "Get the most recently accepted container. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index-getlastaccepted)"
+							},
+							"response": []
+						},
+						{
+							"name": "getContainerByIndex",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerByIndex\",\n    \"params\": {\n        \"index\":0,\n        \"encoding\":\"cb58\"\n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{http}}://{{host}}:{{port}}/ext/index/P/block",
+									"protocol": "{{http}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"ext",
+										"index",
+										"P",
+										"block"
+									]
+								},
+								"description": "Get container by index. The first container accepted is at index 0, the second is at index 1, etc. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index-getcontainerbyindex)"
+							},
+							"response": []
+						},
+						{
+							"name": "getContainerRange",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerRange\",\n    \"params\": {\n        \"startIndex\":0,\n        \"numtoFetch\":10,\n        \"encoding\":\"cb58\"\n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{http}}://{{host}}:{{port}}/ext/index/P/block",
+									"protocol": "{{http}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"ext",
+										"index",
+										"P",
+										"block"
+									]
+								},
+								"description": "Returns containers with indices in [startIndex, startIndex+1, ... , startIndex + numToFetch - 1]. numToFetch must be in \\[0,1024\\] [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index-getcontainerrange)"
+							},
+							"response": []
+						},
+						{
+							"name": "getIndex",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getIndex\",\n    \"params\": {\n        \"containerID\":\"4AqeFPxtTW4B5D6oR8gRZTvRKnnqkUWiV6mUNZxjUMbQKYWpi\",\n        \"encoding\":\"cb58\"\n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{http}}://{{host}}:{{port}}/ext/index/P/block",
+									"protocol": "{{http}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"ext",
+										"index",
+										"P",
+										"block"
+									]
+								},
+								"description": "Get a container's index. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index-getindex)"
+							},
+							"response": []
+						},
+						{
+							"name": "isAccepted",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.isAccepted\",\n    \"params\": {\n        \"containerID\":\"4AqeFPxtTW4B5D6oR8gRZTvRKnnqkUWiV6mUNZxjUMbQKYWpi\",\n        \"encoding\":\"cb58\"\n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{http}}://{{host}}:{{port}}/ext/index/P/block",
+									"protocol": "{{http}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"ext",
+										"index",
+										"P",
+										"block"
+									]
+								},
+								"description": "Returns true if the container is in this index. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index-isaccepted)"
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "C-Chain Blocks",
+					"item": [
+						{
+							"name": "getLastAccepted",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getLastAccepted\",\n    \"params\": {\n        \"encoding\":\"cb58\"\n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{http}}://{{host}}:{{port}}/ext/index/C/block",
+									"protocol": "{{http}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"ext",
+										"index",
+										"C",
+										"block"
+									]
+								},
+								"description": "Get the most recently accepted container. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index-getlastaccepted)"
+							},
+							"response": []
+						},
+						{
+							"name": "getContainerByIndex",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerByIndex\",\n    \"params\": {\n        \"index\":0,\n        \"encoding\":\"cb58\"\n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{http}}://{{host}}:{{port}}/ext/index/C/block",
+									"protocol": "{{http}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"ext",
+										"index",
+										"C",
+										"block"
+									]
+								},
+								"description": "Get container by index. The first container accepted is at index 0, the second is at index 1, etc. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index-getcontainerbyindex)"
+							},
+							"response": []
+						},
+						{
+							"name": "getContainerRange",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getContainerRange\",\n    \"params\": {\n        \"startIndex\":0,\n        \"numtoFetch\":10,\n        \"encoding\":\"cb58\"\n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{http}}://{{host}}:{{port}}/ext/index/C/block",
+									"protocol": "{{http}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"ext",
+										"index",
+										"C",
+										"block"
+									]
+								},
+								"description": "Returns containers with indices in [startIndex, startIndex+1, ... , startIndex + numToFetch - 1]. numToFetch must be in \\[0,1024\\] [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index-getcontainerrange)"
+							},
+							"response": []
+						},
+						{
+							"name": "getIndex",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.getIndex\",\n    \"params\": {\n        \"containerID\":\"4AqeFPxtTW4B5D6oR8gRZTvRKnnqkUWiV6mUNZxjUMbQKYWpi\",\n        \"encoding\":\"cb58\"\n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{http}}://{{host}}:{{port}}/ext/index/C/block",
+									"protocol": "{{http}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"ext",
+										"index",
+										"C",
+										"block"
+									]
+								},
+								"description": "Get a container's index. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index-getindex)"
+							},
+							"response": []
+						},
+						{
+							"name": "isAccepted",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"index.isAccepted\",\n    \"params\": {\n        \"containerID\":\"4AqeFPxtTW4B5D6oR8gRZTvRKnnqkUWiV6mUNZxjUMbQKYWpi\",\n        \"encoding\":\"cb58\"\n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{http}}://{{host}}:{{port}}/ext/index/C/block",
+									"protocol": "{{http}}",
+									"host": [
+										"{{host}}"
+									],
+									"port": "{{port}}",
+									"path": [
+										"ext",
+										"index",
+										"C",
+										"block"
+									]
+								},
+								"description": "Returns true if the container is in this index. [More info](https://docs.avax.network/build/avalanchego-apis/index-api#index-isaccepted)"
+							},
+							"response": []
+						}
+					]
+				}
+			],
+			"description": "This API can be used to query data from AvalancheGo's database. The Index API is only available when node is run with --index-enabled option."
+		},
+		{
 			"name": "Info",
 			"item": [
 				{
@@ -2443,7 +3109,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"info.peers\",\n    \"params\" :{\n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"info.peers\",\n    \"params\" :{\n        \"nodeIDs\": []\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -3042,7 +3708,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.getCurrentValidators\",\n    \"params\": {\n        \"subnetID\": \"{{customSubnetID}}\"\n    },\n    \"id\": 1\n}",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.getCurrentValidators\",\n    \"params\": {\n        \"subnetID\":null,\n        \"nodeIDs\":[]\n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -3197,7 +3863,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.getPendingValidators\",\n    \"params\": {\n        \"subnetID\": \"{{avalancheSubnetId}}\"\n    },\n    \"id\": 1\n}",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.getPendingValidators\",\n    \"params\": {\n        \"subnetID\": null,\n        \"nodeIDs\": []\n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"

--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -600,6 +600,37 @@
 					"response": []
 				},
 				{
+					"name": "getAddressTxs",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.getAllBalances\",\n    \"params\" :{\n        \"address\":\"{{xchainAddress}}\"\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/X",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"bc",
+								"X"
+							]
+						},
+						"description": "Returns all transactions that change the balance of the given address. A transaction is said to change an address's balance if either is true:\n\n*   A UTXO that the transaction consumes was at least partially owned by the address.\n*   A UTXO that the transaction produces is at least partially owned by the address.\n    \n\nNote: Indexing (`index-transactions`) must be enabled in the X-chain config. [More info](https://docs.avax.network/build/avalanchego-apis/x-chain#avm-get-address-txs-api)"
+					},
+					"response": []
+				},
+				{
 					"name": "getAllBalances",
 					"request": {
 						"method": "POST",
@@ -3080,7 +3111,7 @@
 								"info"
 							]
 						},
-						"description": "Given a blockchain’s alias, get its ID. [More info](https://docs.avax.network/build/apis/info-api#info-getblockchainid)"
+						"description": "Given a blockchain’s alias, get its ID. [More info](https://docs.avax.network/build/avalanchego-apis/info#infogetblockchainid)"
 					},
 					"response": []
 				},
@@ -3260,7 +3291,7 @@
 								"info"
 							]
 						},
-						"description": "Check whether a given chain is done bootstrapping. [More info](https://docs.avax.network/build/apis/info-api#info-isbootstrapped)"
+						"description": "Check whether a given chain is done bootstrapping. [More info](https://docs.avax.network/build/avalanchego-apis/info-api#infoisbootstrapped)"
 					},
 					"response": []
 				},
@@ -3744,7 +3775,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.createBlockchain\",\n    \"params\" : {\n        \"vmID\":\"avm\",\n        \"SubnetID\":\"{{avalancheSubnetId}}\",\n        \"name\":\"My new avm\",\n        \"genesisData\": \"111115LHK2ZCYttSKPmmhsTDSuKiCkmHz65nUS1YqybvjirwGLLt376k1RwnTt72WobPqrG7rmgrKVqSq6VxDsKXYGnRmfhdLCEhsYjMegZmu5L5wEQ6k1BHu1QN6jk8kfoLQfAnKAxv8t5PmGJUwmTyoHz9aoDpfwJfkzjLut3TSSHzVLzH5bPoc5fYMwKGA1Zaps4Byo6rPpAZgiDG1jokzLuVXFDMxiFSDGHHA7uB5Nx2qaywtUXtyTi7JMYMKQMcB2UQEZbpPB9QcHg88mA8uzT2i5YYSiT9uZpAUjd6cfNiPedBJqi5AdjtcAmHvhszCS7YurbVmB4sHEP3PMxyKAHMnQ8dyxefQCDPUpSGMFp6qzomuXQSQeTi\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.createBlockchain\",\n    \"params\" : {\n        \"vmID\":\"avm\",\n        \"SubnetID\":\"{{avalancheSubnetId}}\",\n        \"name\":\"My new avm\",\n        \"genesisData\": \"111115LHK2ZCYttSKPmmhsTDSuKiCkmHz65nUS1YqybvjirwGLLt376k1RwnTt72WobPqrG7rmgrKVqSq6VxDsKXYGnRmfhdLCEhsYjM\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -3955,6 +3986,37 @@
 					"response": []
 				},
 				{
+					"name": "getTotalStake",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getTotalStake\",\n    \"params\": {}\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"bc",
+								"P"
+							]
+						},
+						"description": "Get the total amount of nAVAX staked on the Primary Network. [More info](https://docs.avax.network/build/avalanchego-apis/p-chain#platformgettotalstake)"
+					},
+					"response": []
+				},
+				{
 					"name": "getCurrentValidators",
 					"request": {
 						"method": "POST",
@@ -3962,6 +4024,37 @@
 						"body": {
 							"mode": "raw",
 							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.getCurrentValidators\",\n    \"params\": {\n        \"subnetID\":null,\n        \"nodeIDs\":[]\n    },\n    \"id\": 1\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"bc",
+								"P"
+							]
+						},
+						"description": "List the current validators of the given Subnet. [More info](https://docs.avax.network/v1.0/en/api/platform/#platformgetcurrentvalidators)"
+					},
+					"response": []
+				},
+				{
+					"name": "getMaxStakeAmount",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.getMaxStakeAmount\",\n    \"params\": {\n        \"subnetID\":\"\",\n        \"nodeID\":\"\",\n        \"startTime\": 123,\n        \"endTime\": 321\n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -4265,6 +4358,37 @@
 					"response": []
 				},
 				{
+					"name": "getTimestamp",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getTimestamp\",\n    \"params\" :{}\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/bc/P",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"bc",
+								"P"
+							]
+						},
+						"description": "Returns the specified transaction [More info](https://docs.avax.network/v1.0/en/api/avm/#avmgetbalance)"
+					},
+					"response": []
+				},
+				{
 					"name": "getTxStatus",
 					"request": {
 						"method": "POST",
@@ -4302,7 +4426,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getUTXOs\",\n    \"params\" :{\n        \"addresses\":[\"P-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u\"],\n        \"sourceChain\": \"X\",\n        \"limit\": 5,\n        \"encoding\": \"hex\"\n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getUTXOs\",\n    \"params\" :{\n        \"addresses\":[\"P-custom18jma8ppw3nhx5r4ap8clazz0dps7rv5u9xde7p\"],\n        \"sourceChain\": \"X\",\n        \"limit\": 5,\n        \"encoding\": \"hex\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"

--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -202,7 +202,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"auth.newToken\",\n    \"params\": {\n        \"password\":\"YOUR PASSWORD GOES HERE\",\n        \"endpoints\":[\"/ext/bc/X\", \"/ext/info\"]\n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"auth.newToken\",\n    \"params\": {\n        \"password\":\"{{authPassword}}\",\n        \"endpoints\":[\"/ext/bc/X\", \"/ext/info\"]\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -722,7 +722,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.importAVAX\",\n    \"params\" :{\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"to\":\"X-local1q9styn7wfk5mtlg76cy9sczgt3tavkjq0awk2w\"\n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.importAVAX\",\n    \"params\" :{\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"sourceChain\": \"P\",\n        \"to\":\"{{xchainAddress}}\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -752,7 +752,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.importKey\",\n    \"params\" :{\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\",\n        \"privateKey\":\"PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN\"\n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.importKey\",\n    \"params\" :{\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\",\n        \"privateKey\":\"{{privkey}}\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -760,7 +760,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/X",
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/X",
 							"protocol": "{{http}}",
 							"host": [
 								"{{host}}"
@@ -768,6 +768,7 @@
 							"port": "{{port}}",
 							"path": [
 								"ext",
+								"bc",
 								"X"
 							]
 						},
@@ -1286,7 +1287,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"avax.importKey\",\n    \"params\": {\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"privateKey\":\"{{cchainAddress}}\"\n    },\n    \"id\": 1\n}",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"avax.importKey\",\n    \"params\": {\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"privateKey\":\"{{privkey}}\"\n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -2912,7 +2913,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.importKey\",\n    \"params\" :{\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"privateKey\":\"PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN\"\n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.importKey\",\n    \"params\" :{\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"privateKey\":\"{{privkey}}\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"

--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -2776,7 +2776,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.createSubnet\",\n    \"params\": {\n        \"controlKeys\":[\n            \"{{pchainAddress}}\"\n        ],\n        \"threshold\":1,\n        \"from\": [{{pchainAddress}}]\n        \"changeAddr\":\"{{pchainAddress}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.createSubnet\",\n    \"params\": {\n        \"controlKeys\":[\n            \"{{pchainAddress}}\"\n        ],\n        \"threshold\":1,\n        \"from\": [\"{{pchainAddress}}\"],\n        \"changeAddr\":\"{{pchainAddress}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"

--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -189,8 +189,7 @@
 					"response": []
 				}
 			],
-			"description": "This API can be used for measuring node health and debugging. [More info](https://docs.avax.network/v1.0/en/api/admin)",
-			"protocolProfileBehavior": {}
+			"description": "This API can be used for measuring node health and debugging. [More info](https://docs.avax.network/v1.0/en/api/admin)"
 		},
 		{
 			"name": "Auth",
@@ -286,8 +285,7 @@
 					"response": []
 				}
 			],
-			"description": "This API can be used for measuring node health and debugging. [More info](https://docs.avax.network/v1.0/en/api/admin)",
-			"protocolProfileBehavior": {}
+			"description": "This API can be used for measuring node health and debugging. [More info](https://docs.avax.network/v1.0/en/api/admin)"
 		},
 		{
 			"name": "AVM",
@@ -299,7 +297,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"id\"     : 1,\n    \"method\" : \"avm.buildGenesis\",\n    \"params\" : {\n        \"genesisData\": {\n            \"asset1\": {\n                \"name\": \"myFixedCapAsset\",\n                \"symbol\":\"MFCA\",\n                \"initialState\": {\n                    \"fixedCap\" : [\n                        {\n                            \"amount\":100000,\n                            \"address\": \"8UeduLccQuSmYiY3fGQEyotM9uXxoHoQQ\"\n                        },\n                        {\n                            \"amount\":100000,\n                            \"address\": \"AgVkHvvDShLumJrzXzkwuHa7rYpewj9Kg\"\n                        },\n                        {\n                            \"amount\":50000,\n                            \"address\": \"AwBDGsUwNdXgVc8XG2E8A8dL3bkoVbkL9\"\n                        },\n                        {\n                            \"amount\":50000,\n                            \"address\": \"AATN8YjgmFjC2jQRq45sEeGcBFXNYPcM8\"\n                        }\n                    ]\n                }\n            },\n            \"asset2\": {\n                \"name\": \"myVarCapAsset\",\n                \"symbol\":\"MVCA\",\n                \"initialState\": {\n                    \"variableCap\" : [\n                        {\n                            \"minters\": [\n                                \"AATN8YjgmFjC2jQRq45sEeGcBFXNYPcM8\",\n                                \"FNqMDYafoDVYQ2o4a7Zd9maJAxcUEieQb\"\n                            ],\n                            \"threshold\":1\n                        },\n                        {\n                            \"minters\": [\n                                \"JJSiKQfha9Z2TiMxBZ8XdW9F6KFw8aKS4\",\n                                \"7jJHY1vZL6AAbCFb97KMLY8nqMQVyd5JG\",\n                                \"58pM5cEf1wMSncPdCwtQ8tbHs2xdMA4eo\"\n                            ],\n                            \"threshold\":2\n                        }\n                    ]\n                }\n            }\n        }\n    }\n}",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"id\"     : 1,\n    \"method\" : \"avm.buildGenesis\",\n    \"params\" : {\n        \"genesisData\": {\n            \"asset1\": {\n                \"name\": \"myFixedCapAsset\",\n                \"symbol\":\"MFCA\",\n                \"initialState\": {\n                    \"fixedCap\" : [\n                        {\n                            \"amount\":100000,\n                            \"address\": \"local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u\"\n                        }\n                    ]\n                }\n            },\n            \"asset2\": {\n                \"name\": \"myVarCapAsset\",\n                \"symbol\":\"MVCA\",\n                \"initialState\": {\n                    \"variableCap\" : [\n                        {\n                            \"minters\": [\n                                \"local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u\"\n                            ],\n                            \"threshold\":1\n                        }\n                    ]\n                }\n            }\n        }\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -608,7 +606,6 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "f7d94043-85db-4047-999d-24b4e3b97254",
 								"exec": [
 									"var template = `",
 									"    <table bgcolor=\"#FFFFFF\">",
@@ -649,7 +646,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/X",
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/X",
 							"protocol": "{{http}}",
 							"host": [
 								"{{host}}"
@@ -657,6 +654,7 @@
 							"port": "{{port}}",
 							"path": [
 								"ext",
+								"bc",
 								"X"
 							]
 						},
@@ -795,7 +793,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.importAVAX\",\n    \"params\" :{\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"sourceChain\": \"P\",\n        \"to\":\"{{xchainAddress}}\"\n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.importAVAX\",\n    \"params\" :{\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"sourceChain\": \"C\",\n        \"to\":\"{{xchainAddress}}\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -816,37 +814,6 @@
 							]
 						},
 						"description": "Finalize a transfer of AVAX from either the P-Chain to the X-Chain or the C-Chain to the X-Chain.\n\nBefore this method is called, you must call either the P-Chain’s `exportAVAX` method or the C-Chain’s `exportAVAX` method to initiate the transfer. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-importavax)"
-					},
-					"response": []
-				},
-				{
-					"name": "importKey",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.importKey\",\n    \"params\" :{\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\",\n        \"privateKey\":\"{{privkey}}\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/X",
-							"protocol": "{{http}}",
-							"host": [
-								"{{host}}"
-							],
-							"port": "{{port}}",
-							"path": [
-								"ext",
-								"bc",
-								"X"
-							]
-						},
-						"description": "Give a user control over an address by providing the private key that controls the address. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-importkey)"
 					},
 					"response": []
 				},
@@ -878,6 +845,37 @@
 							]
 						},
 						"description": "Send a signed transaction to the network. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-issuetx)"
+					},
+					"response": []
+				},
+				{
+					"name": "importKey",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.importKey\",\n    \"params\" :{\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\",\n        \"privateKey\":\"{{privkey}}\"\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/X",
+							"protocol": "{{http}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"bc",
+								"X"
+							]
+						},
+						"description": "Give a user control over an address by providing the private key that controls the address. [More info](https://docs.avax.network/build/apis/exchange-chain-x-chain-api#avm-importkey)"
 					},
 					"response": []
 				},
@@ -1068,8 +1066,7 @@
 					"response": []
 				}
 			],
-			"description": "The X-Chain, Avalanche’s native platform for creating and trading assets, is an instance of the Avalanche Virtual Machine (AVM). This API allows clients to create and trade assets on the X-Chain and other instances of the AVM. [More info](https://docs.avax.network/v1.0/en/api/avm)",
-			"protocolProfileBehavior": {}
+			"description": "The X-Chain, Avalanche’s native platform for creating and trading assets, is an instance of the Avalanche Virtual Machine (AVM). This API allows clients to create and trade assets on the X-Chain and other instances of the AVM. [More info](https://docs.avax.network/v1.0/en/api/avm)"
 		},
 		{
 			"name": "EVM",
@@ -2035,8 +2032,7 @@
 					"response": []
 				}
 			],
-			"description": "This document describes the API of the C-Chain, which is an instance of the Ethereum Virtual Machine (EVM.)\n\nNote: Ethereum has its own notion of `networkID` and `chainID`. The C-Chain uses `1` and `43110` for these values, obtained using the `net_version` and `eth_chainId` methods shown below. These have no relationship to AVA’s view of networkID and chainID, and are purely internal to the C-Chain. [More info](https://docs.avax.network/v1.0/en/api/evm)",
-			"protocolProfileBehavior": {}
+			"description": "This document describes the API of the C-Chain, which is an instance of the Ethereum Virtual Machine (EVM.)\n\nNote: Ethereum has its own notion of `networkID` and `chainID`. The C-Chain uses `1` and `43110` for these values, obtained using the `net_version` and `eth_chainId` methods shown below. These have no relationship to AVA’s view of networkID and chainID, and are purely internal to the C-Chain. [More info](https://docs.avax.network/v1.0/en/api/evm)"
 		},
 		{
 			"name": "Health",
@@ -2072,8 +2068,7 @@
 					"response": []
 				}
 			],
-			"description": "This API can be used for measuring node health. [More info](https://docs.avax.network/v1.0/en/api/health)",
-			"protocolProfileBehavior": {}
+			"description": "This API can be used for measuring node health. [More info](https://docs.avax.network/v1.0/en/api/health)"
 		},
 		{
 			"name": "Info",
@@ -2349,8 +2344,7 @@
 					"response": []
 				}
 			],
-			"description": "This API can be used to access basic information about the node.",
-			"protocolProfileBehavior": {}
+			"description": "This API can be used to access basic information about the node."
 		},
 		{
 			"name": "IPC",
@@ -2416,8 +2410,7 @@
 					"response": []
 				}
 			],
-			"description": "The IPC API allows users to create a UNIX domain socket for a blockchain to publish to. When the blockchain accepts a vertex/block it will publish the vertex to the socket.\n\nA node will only expose this API if it is started with command-line argument `api-ipcs-enabled=true`. [More info](https://docs.avax.network/v1.0/en/api/ipc/)",
-			"protocolProfileBehavior": {}
+			"description": "The IPC API allows users to create a UNIX domain socket for a blockchain to publish to. When the blockchain accepts a vertex/block it will publish the vertex to the socket.\n\nA node will only expose this API if it is started with command-line argument `api-ipcs-enabled=true`. [More info](https://docs.avax.network/v1.0/en/api/ipc/)"
 		},
 		{
 			"name": "Keystore",
@@ -2573,8 +2566,7 @@
 					"response": []
 				}
 			],
-			"description": "Every node has a built-in keystore. Clients create users on the keystore, which act as identities to be used when interacting with blockchains. A keystore exists at the node level, so if you create a user on a node it exists only on that node. However, users may be imported and exported using this API. \n\n**You should only create a keystore user on a node that you operate, as the node operator has access to your plaintext password.**\n\n[More info](https://docs.avax.network/v1.0/en/api/keystore)",
-			"protocolProfileBehavior": {}
+			"description": "Every node has a built-in keystore. Clients create users on the keystore, which act as identities to be used when interacting with blockchains. A keystore exists at the node level, so if you create a user on a node it exists only on that node. However, users may be imported and exported using this API. \n\n**You should only create a keystore user on a node that you operate, as the node operator has access to your plaintext password.**\n\n[More info](https://docs.avax.network/v1.0/en/api/keystore)"
 		},
 		{
 			"name": "Metrics",
@@ -2586,10 +2578,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "",
-							"options": {
-								"raw": {}
-							}
+							"raw": ""
 						},
 						"url": {
 							"raw": "{{http}}://{{host}}:{{port}}/ext/metrics",
@@ -2608,8 +2597,7 @@
 					"response": []
 				}
 			],
-			"description": "The API allows clients to get statistics about a node’s health and performance. [More info](https://docs.avax.network/v1.0/en/api/metrics/)",
-			"protocolProfileBehavior": {}
+			"description": "The API allows clients to get statistics about a node’s health and performance. [More info](https://docs.avax.network/v1.0/en/api/metrics/)"
 		},
 		{
 			"name": "PlatformVM",
@@ -2745,7 +2733,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.createBlockchain\",\n    \"params\" : {\n        \"vmID\":\"timestamp\",\n        \"SubnetID\":\"{{avalancheSubnetId}}\",\n        \"name\":\"My new timestamp\",\n        \"genesisData\": \"45oj4CqFViNHUtBxJ55TZfqaVAXFwMRMj2XkHVqUYjJYoTaEM\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.createBlockchain\",\n    \"params\" : {\n        \"vmID\":\"avm\",\n        \"SubnetID\":\"{{avalancheSubnetId}}\",\n        \"name\":\"My new avm\",\n        \"genesisData\": \"111115LHK2ZCYttSKPmmhsTDSuKiCkmHz65nUS1YqybvjirwGLLt376k1RwnTt72WobPqrG7rmgrKVqSq6VxDsKXYGnRmfhdLCEhsYjMegZmu5L5wEQ6k1BHu1QN6jk8kfoLQfAnKAxv8t5PmGJUwmTyoHz9aoDpfwJfkzjLut3TSSHzVLzH5bPoc5fYMwKGA1Zaps4Byo6rPpAZgiDG1jokzLuVXFDMxiFSDGHHA7uB5Nx2qaywtUXtyTi7JMYMKQMcB2UQEZbpPB9QcHg88mA8uzT2i5YYSiT9uZpAUjd6cfNiPedBJqi5AdjtcAmHvhszCS7YurbVmB4sHEP3PMxyKAHMnQ8dyxefQCDPUpSGMFp6qzomuXQSQeTi\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -3545,9 +3533,7 @@
 					"response": []
 				}
 			],
-			"description": "This API allows clients to interact with the P-Chain (Platform Chain), which maintains Avalanche’s validator set and handles blockchain creation. [More info](https://docs.avax.network/v1.0/en/api/platform)",
-			"protocolProfileBehavior": {}
+			"description": "This API allows clients to interact with the P-Chain (Platform Chain), which maintains Avalanche’s validator set and handles blockchain creation. [More info](https://docs.avax.network/v1.0/en/api/platform)"
 		}
-	],
-	"protocolProfileBehavior": {}
+	]
 }

--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -3416,6 +3416,36 @@
 					"response": []
 				},
 				{
+					"name": "getVMs",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"info.getVMs\",\n    \"params\": {\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{protocol}}://{{host}}:{{port}}/ext/info",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"info"
+							]
+						},
+						"description": "Get the virtual machines installed on this node. [More info](https://docs.avax.network/build/avalanchego-apis/info#infogetvms)"
+					},
+					"response": []
+				},
+				{
 					"name": "uptime",
 					"request": {
 						"method": "POST",

--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -1822,6 +1822,36 @@
 					"response": []
 				},
 				{
+					"name": "isBootstrapped",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"info.isBootstrapped\",\n    \"params\": {\n        \"chain\": \"X\"\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{http}}://{{host}}:{{port}}/ext/info",
+							"protocol": "{{http}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"info"
+							]
+						},
+						"description": "Check whether a given chain is done bootstrapping. [More info](https://docs.avax.network/v1.0/en/api/info/#infoisbootstrapped)"
+					},
+					"response": []
+				},
+				{
 					"name": "getTxFee",
 					"request": {
 						"method": "POST",
@@ -2635,7 +2665,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getUTXOs\",\n    \"params\" :{\n        \"addresses\":[\"{{pchainAddress}}\"],\n        \"limit\": 5\n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getUTXOs\",\n    \"params\" :{\n        \"addresses\":[\"P-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u\"],\n        \"sourceChain\": \"X\",\n        \"limit\": 5\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"

--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -15,7 +15,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"admin.alias\",\n    \"params\": {\n        \"alias\":\"myAlias\",\n        \"endpoint\":\"bc/x\"\n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"admin.alias\",\n    \"params\": {\n        \"alias\":\"myAlias\",\n        \"endpoint\":\"bc/X\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -135,7 +135,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"admin.startCPUProfiler\",\n    \"params\" :{\n        \"fileName\":\"cpu.profile\"\n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"admin.startCPUProfiler\",\n    \"params\" :{\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -450,7 +450,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.exportAVAX\",\n    \"params\" :{\n        \"to\":\"P-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u\",\n        \"amount\": 4000001000000,\n        \"destinationChain\": \"P\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.exportAVAX\",\n    \"params\" :{\n        \"to\":\"{{pchainAddress}}\",\n        \"amount\": 4000001000000,\n        \"destinationChain\": \"P\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -842,7 +842,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.mint\",\n    \"params\" :{\n        \"amount\":10000000,\n        \"assetID\":\"MHSxjU1wGfBWPL3eC47ri8aKH9HhLUtRDurZqALDNzBne2NTU\",\n        \"to\":\"{{xchainAddress}}\",\n        \"minters\":[\n            \"X-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u\"\n        ],\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     : 1,\n    \"method\" :\"avm.mint\",\n    \"params\" :{\n        \"amount\":10000000,\n        \"assetID\":\"2qnR9pLQTDZ9boSbcrcjS4n1DJJkzbkNsJzgwYvmRy8uv47fZT\",\n        \"to\":\"{{xchainAddress}}\",\n        \"minters\":[\n            \"{{xchainAddress}}\"\n        ],\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -932,7 +932,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.sendNFT\",\n    \"params\" :{ \n        \"assetID\" :\"6DP2VKHJFyfFWJ3FXbFrm8FSNSMuHVpSB1GZY8geAfd58HxQy\",\n        \"to\"      :\"X-local1q9styn7wfk5mtlg76cy9sczgt3tavkjq0awk2w\",\n        \"groupID\" : 0,\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.sendNFT\",\n    \"params\" :{ \n        \"assetID\" :\"2Y1VBSy8WX5T7f7ifMPpjm8jbFWYvVv1iSQefhAcpwokhk2GXX\",\n        \"to\"      :\"{{xchainAddress}}\",\n        \"groupID\" : 0,\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1193,7 +1193,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"ava.importAVAX\",\n    \"params\": {\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"sourceChain\": \"X\",\n        \"to\":\"0x4b879aff6b3d24352Ac1985c1F45BA4c3493A398\"\n    },\n    \"id\": 1\n}",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"avax.importAVAX\",\n    \"params\": {\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"sourceChain\": \"X\",\n        \"to\":\"0x4b879aff6b3d24352Ac1985c1F45BA4c3493A398\"\n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1201,7 +1201,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/ava",
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/avax",
 							"protocol": "{{http}}",
 							"host": [
 								"{{host}}"
@@ -1211,7 +1211,7 @@
 								"ext",
 								"bc",
 								"C",
-								"ava"
+								"avax"
 							]
 						}
 					},
@@ -1224,7 +1224,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"ava.exportAVAX\",\n    \"params\": {\n        \"to\":\"{{xchainAddress}}\",\n        \"amount\": 99000000,\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    },\n    \"id\": 1\n}",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"avax.exportAVAX\",\n    \"params\": {\n        \"to\":\"{{xchainAddress}}\",\n        \"amount\": 99000000,\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1232,7 +1232,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/ava",
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/avax",
 							"protocol": "{{http}}",
 							"host": [
 								"{{host}}"
@@ -1242,7 +1242,7 @@
 								"ext",
 								"bc",
 								"C",
-								"ava"
+								"avax"
 							]
 						}
 					},
@@ -1255,7 +1255,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"ava.exportKey\",\n    \"params\": {\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"address\":\"{{cchainAddress}}\"\n    },\n    \"id\": 1\n}",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"avax.exportKey\",\n    \"params\": {\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"address\":\"{{cchainAddress}}\"\n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1263,7 +1263,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/ava",
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/avax",
 							"protocol": "{{http}}",
 							"host": [
 								"{{host}}"
@@ -1273,7 +1273,7 @@
 								"ext",
 								"bc",
 								"C",
-								"ava"
+								"avax"
 							]
 						}
 					},
@@ -1286,7 +1286,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"ava.importKey\",\n    \"params\": {\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"privateKey\":\"{{cchainAddress}}\"\n    },\n    \"id\": 1\n}",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"avax.importKey\",\n    \"params\": {\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"privateKey\":\"{{cchainAddress}}\"\n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1294,7 +1294,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/ava",
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/avax",
 							"protocol": "{{http}}",
 							"host": [
 								"{{host}}"
@@ -1304,7 +1304,7 @@
 								"ext",
 								"bc",
 								"C",
-								"ava"
+								"avax"
 							]
 						}
 					},
@@ -2251,7 +2251,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.addDelegator\",\n    \"params\": {\n        \"nodeId\":\"{{avalancheNodeId}}\",\n        \"startTime\":1598726193,\n        \"endTime\":1599317594,\n        \"stakeAmount\":20000000000,\n        \"rewardAddress\": \"{{pchainAddress}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.addDelegator\",\n    \"params\": {\n        \"nodeId\":\"{{avalancheNodeId}}\",\n        \"startTime\":1600406351,\n        \"endTime\":1602997371,\n        \"stakeAmount\":200000000000,\n        \"rewardAddress\": \"{{pchainAddress}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -2611,7 +2611,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getStake\",\n    \"params\": {\n        \"addresses\": []\n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getStake\",\n    \"params\": {\n        \"addresses\": [{{pchainAddress}}]\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -3087,75 +3087,6 @@
 				}
 			],
 			"description": "This API allows clients to interact with the P-Chain (Platform Chain), which maintains Avalanche’s validator set and handles blockchain creation. [More info](https://docs.avax.network/v1.0/en/api/platform)",
-			"protocolProfileBehavior": {}
-		},
-		{
-			"name": "Timestamp",
-			"item": [
-				{
-					"name": "getBlock",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"timestamp.getBlock\",\n    \"params\":{\n        \"id\":\"xqQV1jDnCXDxhfnNT7tDBcXeoH2jC3Hh7Pyv4GXE1z1hfup5K\"\n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/timestamp",
-							"protocol": "{{http}}",
-							"host": [
-								"{{host}}"
-							],
-							"port": "{{port}}",
-							"path": [
-								"ext",
-								"bc",
-								"timestamp"
-							]
-						},
-						"description": "Get a block by its ID. If no ID is provided, get the latest block. [More info](https://docs.avax.network/v1.0/en/api/timestamp/#timestampgetblock)"
-					},
-					"response": []
-				},
-				{
-					"name": "proposeBlock",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"timestamp.proposeBlock\",\n    \"params\":{\n        \"data\":\"SkB92YpWm4Q2iPnLGCuDPZPgUQMxajqQQuz91oi3xD984f8r\"\n    },\n    \"id\": 1\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/timestamp",
-							"protocol": "{{http}}",
-							"host": [
-								"{{host}}"
-							],
-							"port": "{{port}}",
-							"path": [
-								"ext",
-								"bc",
-								"timestamp"
-							]
-						},
-						"description": "Propose the creation of a new block. [More info](https://docs.avax.network/v1.0/en/api/timestamp/#timestampproposeblock)"
-					},
-					"response": []
-				}
-			],
-			"description": "This API allows clients to interact with the Timestamp Chain.\n\nThe Timestamp Chain is a timestamp server. Each block contains a 32 byte payload and the timestamp when the block was created.\n\nThe genesis data for a new instance of the Timestamp Chain is the genesis block’s 32 byte payload. [More info](https://docs.avax.network/v1.0/en/api/timestamp)",
 			"protocolProfileBehavior": {}
 		}
 	],

--- a/Avalanche.postman_collection.json
+++ b/Avalanche.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "e935c935-aad0-4d36-99ea-db1283e94515",
+		"_postman_id": "e337c02e-d072-4741-b24f-e38be44db4b7",
 		"name": "Avalanche",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -75,7 +75,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"admin.lockProfile\",\n    \"params\" :{\n        \"fileName\":\"lock.profile\"\n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"admin.lockProfile\",\n    \"params\" :{}\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -105,7 +105,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"admin.memoryProfile\",\n    \"params\" :{\n        \"fileName\":\"mem.profile\"\n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"admin.memoryProfile\",\n    \"params\" :{}\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -472,7 +472,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "cf50830d-fafc-4a6d-b0d7-2f596b44ae1b",
+								"id": "f7d94043-85db-4047-999d-24b4e3b97254",
 								"exec": [
 									"var template = `",
 									"    <table bgcolor=\"#FFFFFF\">",
@@ -625,7 +625,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.importAVA\",\n    \"params\" :{\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"to\":\"{{xchainAddress}}\"\n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.importAVAX\",\n    \"params\" :{\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"to\":\"X-local1q9styn7wfk5mtlg76cy9sczgt3tavkjq0awk2w\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -806,6 +806,36 @@
 						"body": {
 							"mode": "raw",
 							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.send\",\n    \"params\" :{ \n        \"assetID\" :\"{{avaxAssetId}}\",\n        \"amount\"  :10000,\n        \"to\"      :\"{{xchainAddress}}\",\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{http}}://{{host}}:{{port}}/ext/X",
+							"protocol": "{{http}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"X"
+							]
+						},
+						"description": "Send a quantity of an asset to an address. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmsend)"
+					},
+					"response": []
+				},
+				{
+					"name": "sendNFT",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"avm.sendNFT\",\n    \"params\" :{ \n        \"assetID\" :\"6DP2VKHJFyfFWJ3FXbFrm8FSNSMuHVpSB1GZY8geAfd58HxQy\",\n        \"to\"      :\"X-local1q9styn7wfk5mtlg76cy9sczgt3tavkjq0awk2w\",\n        \"groupID\" : 0,\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\" \n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1056,6 +1086,130 @@
 							]
 						},
 						"description": "Calculate a cryptographic hash.\n\nThe input parameter contains hexidecimal bytes of arbitrary length. The example here uses the UTF-8 text string “snowstorm” converted to hexidecimal bytes. [More info](https://docs.avax.network/v1.0/en/api/evm/#calculate-a-cryptographic-hash)"
+					},
+					"response": []
+				},
+				{
+					"name": "importAVAX",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"ava.importAVAX\",\n    \"params\": {\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"sourceChain\": \"jnUjZSRt16TcRnZzmh5aMhavwVHz3zBrSN8GfFMTQkzUnoBxC\",\n        \"to\":\"c876DF0F099b3eb32cBB78820d39F5813f73E18C\"\n    },\n    \"id\": 1\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/ava",
+							"protocol": "{{http}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"bc",
+								"C",
+								"ava"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "ExportAVAX",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"ava.importAVAX\",\n    \"params\": {\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"sourceChain\": \"jnUjZSRt16TcRnZzmh5aMhavwVHz3zBrSN8GfFMTQkzUnoBxC\",\n        \"to\":\"c876DF0F099b3eb32cBB78820d39F5813f73E18C\"\n    },\n    \"id\": 1\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/ava",
+							"protocol": "{{http}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"bc",
+								"C",
+								"ava"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "exportKey",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"ava.exportKey\",\n    \"params\": {\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"address\":\"{{cchainAddress}}\"\n    },\n    \"id\": 1\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/ava",
+							"protocol": "{{http}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"bc",
+								"C",
+								"ava"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "importKey",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"ava.exportKey\",\n    \"params\": {\n        \"username\":\"{{avalancheUsername}}\",\n        \"password\":\"{{avalanchePassword}}\",\n        \"address\":\"{{cchainAddress}}\"\n    },\n    \"id\": 1\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/C/ava",
+							"protocol": "{{http}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"bc",
+								"C",
+								"ava"
+							]
+						}
 					},
 					"response": []
 				},
@@ -1934,13 +2088,13 @@
 			"name": "PlatformVM",
 			"item": [
 				{
-					"name": "addDefaultSubnetDelegator",
+					"name": "addDelegator",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.addDefaultSubnetDelegator\",\n    \"params\": {\n        \"nodeId\":\"{{avalancheNodeId}}\",\n        \"destination\":\"{{pchainAddress}}\",\n        \"startTime\":1598726193,\n        \"endTime\":1599317594,\n        \"stakeAmount\":100000,\n        \"rewardAddress\": \"{{pchainAddress}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.addDelegator\",\n    \"params\": {\n        \"nodeId\":\"{{avalancheNodeId}}\",\n        \"startTime\":1598726193,\n        \"endTime\":1599317594,\n        \"stakeAmount\":20000000000,\n        \"rewardAddress\": \"{{pchainAddress}}\",\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1964,13 +2118,13 @@
 					"response": []
 				},
 				{
-					"name": "addDefaultSubnetValidator",
+					"name": "addValidator",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.addDefaultSubnetValidator\",\n    \"params\": {\n        \"nodeID\":\"{{avalancheNodeId}}\",\n        \"startTime\":1597784180,\n        \"endTime\":1597894180,\n        \"stakeAmount\":1000000,\n        \"rewardAddress\": \"{{pchainAddress}}\",\n        \"delegationFeeRate\":10,\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.addValidator\",\n    \"params\": {\n        \"nodeID\":\"{{avalancheNodeId}}\",\n        \"startTime\":1598664856,\n        \"endTime\":1601256253,\n        \"stakeAmount\":200000000000,\n        \"rewardAddress\": \"{{pchainAddress}}\",\n        \"delegationFeeRate\":10,\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1994,13 +2148,13 @@
 					"response": []
 				},
 				{
-					"name": "addNonDefaultSubnetValidator",
+					"name": "addSubnetValidator",
 					"request": {
 						"method": "POST",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.addNonDefaultSubnetValidator\",\n    \"params\": {\n        \"nodeID\":\"{{avalancheNodeId}}\",\n        \"subnetID\":\"{{avalancheSubnetId}}\",\n        \"startTime\":1583524047,\n        \"endTime\":1604102399,\n        \"weight\":1,\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
+							"raw": "{\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"platform.addSubnetValidator\",\n    \"params\": {\n        \"nodeID\":\"{{avalancheNodeId}}\",\n        \"subnetID\":\"{{avalancheSubnetId}}\",\n        \"startTime\":1583524047,\n        \"endTime\":1604102399,\n        \"weight\":1,\n        \"username\": \"{{avalancheUsername}}\",\n        \"password\": \"{{avalanchePassword}}\"\n    },\n    \"id\": 1\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -2368,7 +2522,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{http}}://{{host}}:{{port}}/ext/P",
+							"raw": "{{http}}://{{host}}:{{port}}/ext/bc/P",
 							"protocol": "{{http}}",
 							"host": [
 								"{{host}}"
@@ -2391,7 +2545,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getTxStatus\",\n    \"params\" :{\n        \"txID\":\"LK5gemsUXLQEuAjq37iGct2E5GC72KKLZxaVoDF7foQiSY6mu\"\n    }\n}",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getTxStatus\",\n    \"params\" :{\n        \"txID\":\"2C3AVShejyq6mLhEXvEGCnpaQi8tRwudBhSbT34hFiytffEFoe\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -2399,19 +2553,48 @@
 							}
 						},
 						"url": {
-							"raw": "http://localhost:9650/ext/bc/P",
-							"protocol": "http",
+							"raw": "{{http}}://{{host}}:{{port}}/ext/P",
+							"protocol": "{{http}}",
 							"host": [
-								"localhost"
+								"{{host}}"
 							],
-							"port": "9650",
+							"port": "{{port}}",
 							"path": [
 								"ext",
-								"bc",
 								"P"
 							]
 						},
 						"description": "Returns the specified transaction [More info](https://docs.avax.network/v1.0/en/api/avm/#avmgetbalance)"
+					},
+					"response": []
+				},
+				{
+					"name": "getUTXOs",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"jsonrpc\":\"2.0\",\n    \"id\"     :1,\n    \"method\" :\"platform.getUTXOs\",\n    \"params\" :{\n        \"addresses\":[\"{{pchainAddress}}\"],\n        \"limit\": 5\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{http}}://{{host}}:{{port}}/ext/P",
+							"protocol": "{{http}}",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"ext",
+								"P"
+							]
+						},
+						"description": "Get the UTXOs that reference a given address. [More info](https://docs.avax.network/v1.0/en/api/avm/#avmgetutxos)"
 					},
 					"response": []
 				},

--- a/Example-Avalanche-Environment.postman_environment.json
+++ b/Example-Avalanche-Environment.postman_environment.json
@@ -115,13 +115,11 @@
 		{
 			"key": "xchainBlockID",
 			"value": "gn5RhN1aCT3dnCpjYkiJtrZr1NCwfaHNkFyuDX16zvAfcNzKN",
-			"type": "default",
 			"enabled": true
 		},
 		{
 			"key": "xhcainBlockHeight",
 			"value": "1000",
-			"type": "default",
 			"enabled": true
 		}
 	],

--- a/Example-Avalanche-Environment.postman_environment.json
+++ b/Example-Avalanche-Environment.postman_environment.json
@@ -44,7 +44,7 @@
 		},
 		{
 			"key": "avaxAssetId",
-			"value": "2TrXx5kLGWa9RP3RiYWi7VkmNbppwPU4DCmTdqwuKzGFE7fsvP",
+			"value": "2fombhL7aGPwj3KH4bfrmJwW6PVnMobf9Y2fn9GwxiAAJyFDbe",
 			"enabled": true
 		},
 		{

--- a/Example-Avalanche-Environment.postman_environment.json
+++ b/Example-Avalanche-Environment.postman_environment.json
@@ -16,8 +16,8 @@
 			"key": "port",
 			"value": "9650",
 			"enabled": true
-		},
-		{
+    },
+    {
 			"key": "avalancheUsername",
 			"value": "YOUR_USERNAME",
 			"enabled": true
@@ -91,9 +91,14 @@
 			"key": "memo",
 			"value": "2ug3siZMAGvW7bvgsaV4NZtvCSF8iuCnRGavujqT32qJ3AW",
 			"enabled": true
-		}
+    },
+    {
+      "key": "baseURL",
+      "value": "https://api.avax.network",
+      "enabled": true
+    }
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2021-05-06T12:16:42.269Z",
+  "_postman_exported_at": "2022-05-06T12:16:42.269Z",
 	"_postman_exported_using": "Postman/8.3.1"
 }

--- a/Example-Avalanche-Environment.postman_environment.json
+++ b/Example-Avalanche-Environment.postman_environment.json
@@ -1,9 +1,9 @@
 {
-	"id": "be0a4966-834c-471f-9576-94d4b9b9f421",
-	"name": "Example_Avalanche_Environment",
+	"id": "bcdd0bd7-4c02-4bfd-a3dc-fa0a49791867",
+	"name": "Example-Avalanche-Environment",
 	"values": [
 		{
-			"key": "http",
+			"key": "protocol",
 			"value": "http",
 			"enabled": true
 		},
@@ -94,6 +94,6 @@
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2020-10-01T04:11:04.042Z",
-	"_postman_exported_using": "Postman/7.33.0"
+	"_postman_exported_at": "2021-05-06T12:16:42.269Z",
+	"_postman_exported_using": "Postman/8.3.1"
 }

--- a/Example-Avalanche-Environment.postman_environment.json
+++ b/Example-Avalanche-Environment.postman_environment.json
@@ -3,27 +3,7 @@
 	"name": "Example-Avalanche-Environment",
 	"values": [
 		{
-			"key": "protocol",
-			"value": "http",
-			"enabled": true
-		},
-		{
-			"key": "host",
-			"value": "localhost",
-			"enabled": true
-		},
-		{
-			"key": "port",
-			"value": "9650",
-			"enabled": true
-    },
-    {
-			"key": "avalancheUsername",
-			"value": "YOUR_USERNAME",
-			"enabled": true
-		},
-		{
-			"key": "avalanchePassword",
+			"key": "authPassword",
 			"value": "YOUR_PASSWORD",
 			"enabled": true
 		},
@@ -38,8 +18,18 @@
 			"enabled": true
 		},
 		{
+			"key": "avalanchePassword",
+			"value": "YOUR_PASSWORD",
+			"enabled": true
+		},
+		{
 			"key": "avalancheSubnetId",
 			"value": "2bGsYJorY6X7RhjPBFs3kYjiNEHo4zGrD2eeyZbb43T2KKi7fM",
+			"enabled": true
+		},
+    {
+			"key": "avalancheUsername",
+			"value": "YOUR_USERNAME",
 			"enabled": true
 		},
 		{
@@ -47,34 +37,19 @@
 			"value": "2fombhL7aGPwj3KH4bfrmJwW6PVnMobf9Y2fn9GwxiAAJyFDbe",
 			"enabled": true
 		},
-		{
-			"key": "xchainAddress",
-			"value": "X-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u",
-			"enabled": true
-		},
-		{
-			"key": "pchainAddress",
-			"value": "P-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u",
-			"enabled": true
-		},
-		{
+    {
+      "key": "baseURL",
+      "value": "https://api.avax.network",
+      "enabled": true
+    },
+    {
+      "key": "blockID",
+      "value": "d7WYmb8VeZNHsny3EJCwMm6QA37s1EHwMxw1Y71V3FqPZ5EFG",
+      "enabled": true
+    },
+    {
 			"key": "cchainAddress",
 			"value": "0x820891f8b95daf5ea7d7ce7667e6bba2dd5c5594",
-			"enabled": true
-		},
-		{
-			"key": "cchainPassphrase",
-			"value": "YOUR_PASSWORD",
-			"enabled": true
-		},
-		{
-			"key": "privkey",
-			"value": "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN",
-			"enabled": true
-		},
-		{
-			"key": "authPassword",
-			"value": "YOUR_PASSWORD",
 			"enabled": true
 		},
 		{
@@ -83,8 +58,18 @@
 			"enabled": true
 		},
 		{
+			"key": "cchainPassphrase",
+			"value": "YOUR_PASSWORD",
+			"enabled": true
+		},
+		{
 			"key": "customSubnetID",
 			"value": "j87H8JFHc3wWQ8FQ3P8gGyu9UHdPcz3BcqNTvJKUG6AJ6DDpF",
+			"enabled": true
+		},
+		{
+			"key": "host",
+			"value": "localhost",
 			"enabled": true
 		},
 		{
@@ -92,11 +77,41 @@
 			"value": "2ug3siZMAGvW7bvgsaV4NZtvCSF8iuCnRGavujqT32qJ3AW",
 			"enabled": true
     },
+		{
+			"key": "pchainAddress",
+			"value": "P-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u",
+			"enabled": true
+		},
+		{
+			"key": "port",
+			"value": "9650",
+			"enabled": true
+    },
+		{
+			"key": "privkey",
+			"value": "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN",
+			"enabled": true
+		},
+		{
+			"key": "protocol",
+			"value": "http",
+			"enabled": true
+		},
     {
-      "key": "baseURL",
-      "value": "https://api.avax.network",
+      "key": "txID",
+      "value": "P4SBqRTDAqJBjeRoDvptCCjPWnzzDZPmK9L7WQ7F9ec8zCtP3",
       "enabled": true
-    }
+    },
+    {
+      "key": "utxo",
+      "value": "KGDvUZzdJRWNYTy2ktU4Huay3UueZ94qNeBfRASnDDdzEYxvu",
+      "enabled": true
+    },
+		{
+			"key": "xchainAddress",
+			"value": "X-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u",
+			"enabled": true
+		}
 	],
 	"_postman_variable_scope": "environment",
   "_postman_exported_at": "2022-05-06T12:16:42.269Z",

--- a/Example-Avalanche-Environment.postman_environment.json
+++ b/Example-Avalanche-Environment.postman_environment.json
@@ -1,5 +1,5 @@
 {
-	"id": "bcdd0bd7-4c02-4bfd-a3dc-fa0a49791867",
+	"id": "475ec814-808e-4a01-bbee-1df0a5fe4801",
 	"name": "Example-Avalanche-Environment",
 	"values": [
 		{
@@ -27,7 +27,7 @@
 			"value": "2bGsYJorY6X7RhjPBFs3kYjiNEHo4zGrD2eeyZbb43T2KKi7fM",
 			"enabled": true
 		},
-    {
+		{
 			"key": "avalancheUsername",
 			"value": "YOUR_USERNAME",
 			"enabled": true
@@ -37,17 +37,17 @@
 			"value": "2fombhL7aGPwj3KH4bfrmJwW6PVnMobf9Y2fn9GwxiAAJyFDbe",
 			"enabled": true
 		},
-    {
-      "key": "baseURL",
-      "value": "https://api.avax.network",
-      "enabled": true
-    },
-    {
-      "key": "blockID",
-      "value": "d7WYmb8VeZNHsny3EJCwMm6QA37s1EHwMxw1Y71V3FqPZ5EFG",
-      "enabled": true
-    },
-    {
+		{
+			"key": "baseURL",
+			"value": "https://api.avax.network",
+			"enabled": true
+		},
+		{
+			"key": "blockID",
+			"value": "d7WYmb8VeZNHsny3EJCwMm6QA37s1EHwMxw1Y71V3FqPZ5EFG",
+			"enabled": true
+		},
+		{
 			"key": "cchainAddress",
 			"value": "0x820891f8b95daf5ea7d7ce7667e6bba2dd5c5594",
 			"enabled": true
@@ -76,7 +76,7 @@
 			"key": "memo",
 			"value": "2ug3siZMAGvW7bvgsaV4NZtvCSF8iuCnRGavujqT32qJ3AW",
 			"enabled": true
-    },
+		},
 		{
 			"key": "pchainAddress",
 			"value": "P-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u",
@@ -86,7 +86,7 @@
 			"key": "port",
 			"value": "9650",
 			"enabled": true
-    },
+		},
 		{
 			"key": "privkey",
 			"value": "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN",
@@ -97,23 +97,35 @@
 			"value": "http",
 			"enabled": true
 		},
-    {
-      "key": "txID",
-      "value": "P4SBqRTDAqJBjeRoDvptCCjPWnzzDZPmK9L7WQ7F9ec8zCtP3",
-      "enabled": true
-    },
-    {
-      "key": "utxo",
-      "value": "KGDvUZzdJRWNYTy2ktU4Huay3UueZ94qNeBfRASnDDdzEYxvu",
-      "enabled": true
-    },
+		{
+			"key": "txID",
+			"value": "P4SBqRTDAqJBjeRoDvptCCjPWnzzDZPmK9L7WQ7F9ec8zCtP3",
+			"enabled": true
+		},
+		{
+			"key": "utxo",
+			"value": "KGDvUZzdJRWNYTy2ktU4Huay3UueZ94qNeBfRASnDDdzEYxvu",
+			"enabled": true
+		},
 		{
 			"key": "xchainAddress",
 			"value": "X-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u",
 			"enabled": true
+		},
+		{
+			"key": "xchainBlockID",
+			"value": "gn5RhN1aCT3dnCpjYkiJtrZr1NCwfaHNkFyuDX16zvAfcNzKN",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "xhcainBlockHeight",
+			"value": "1000",
+			"type": "default",
+			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-  "_postman_exported_at": "2022-05-06T12:16:42.269Z",
-	"_postman_exported_using": "Postman/8.3.1"
+	"_postman_exported_at": "2023-06-01T17:42:08.760Z",
+	"_postman_exported_using": "Postman/10.5.8"
 }

--- a/Example_Avalanche_Environment.postman_environment.json
+++ b/Example_Avalanche_Environment.postman_environment.json
@@ -19,12 +19,12 @@
 		},
 		{
 			"key": "avalancheUsername",
-			"value": "my_username",
+			"value": "YOUR_USERNAME",
 			"enabled": true
 		},
 		{
 			"key": "avalanchePassword",
-			"value": "my_$tr0ng_p@ssw0rd",
+			"value": "YOUR_PASSWORD",
 			"enabled": true
 		},
 		{
@@ -64,11 +64,36 @@
 		},
 		{
 			"key": "cchainPassphrase",
-			"value": "my_$tr0ng_p@ssw0rd",
+			"value": "YOUR_PASSWORD",
+			"enabled": true
+		},
+		{
+			"key": "privkey",
+			"value": "PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN",
+			"enabled": true
+		},
+		{
+			"key": "authPassword",
+			"value": "YOUR_PASSWORD",
+			"enabled": true
+		},
+		{
+			"key": "cchainbech32address",
+			"value": "C-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u",
+			"enabled": true
+		},
+		{
+			"key": "customSubnetID",
+			"value": "j87H8JFHc3wWQ8FQ3P8gGyu9UHdPcz3BcqNTvJKUG6AJ6DDpF",
+			"enabled": true
+		},
+		{
+			"key": "memo",
+			"value": "2ug3siZMAGvW7bvgsaV4NZtvCSF8iuCnRGavujqT32qJ3AW",
 			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2020-08-18T20:58:11.842Z",
-	"_postman_exported_using": "Postman/7.30.1"
+	"_postman_exported_at": "2020-10-01T04:11:04.042Z",
+	"_postman_exported_using": "Postman/7.33.0"
 }

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,29 @@
-MIT License
+BSD 3-Clause License
 
-Copyright (c) 2020 Gabriel Cardona
+Copyright (c) 2021, Ava Labs, Inc.
+All rights reserved.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2021, Ava Labs, Inc.
+Copyright (c) 2022, Ava Labs, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -12,3 +12,8 @@ Postman collection for [Avalanche](https://docs.avax.network).
 ## Contributing
 
 We're hoping to continuously keep this collection up-to-date with the [Avalanche APIs](https://docs.avax.network/v1.0/en/api/intro-apis/), and also add [data visualizations](https://learning.postman.com/docs/sending-requests/visualizer/#visualizing-response-data). If you're able to help improve the Avalanche Postman Collection in any way, first create a feature branch by branching off of `master`, next make the improvements on your feature branch and lastly create a [pull request](https://github.com/cgcardona/avalanche-postman-collection/pulls) to merge your work back in to `master`.
+
+
+## Version
+
+v1.6.1

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Postman collection for [Avalanche](https://docs.avax.network).
 
 1. Download [Postman](https://postman.com)
 1. Import Avalanche Postman Collection. Import -> Upload Files -> `Avalanche.postman_collection.json`
-1. Import the Example Avalanche Postman Envirnonment. Settings -> Import -> Choose Files -> `Example_Avalanche_Environment.postman_environment.json`
+1. Import the Example Avalanche Postman Environment. Settings -> Import -> Choose Files -> `Example_Avalanche_Environment.postman_environment.json`
 1. Call any Avalanche RPC endpoint
 
 ## Contributing


### PR DESCRIPTION
Diff can be [seen here](https://github.com/ava-labs/avalanche-postman-collection/pull/25)

This PR adds:

- avm.getBlock
- avm.getBlockByHeight
- avm.getHeight


**Deprecated all ipcs APIs**

- ipcs.publishBlockchain
- ipcs.unpublishBlockchain
- ipcs.getPublishedBlockchains
- Deprecated all keystore APIs
- keystore.createUser
- keystore.deleteUser
- keystore.listUsers
- keystore.importUser
- keystore.exportUser

**Deprecated Avm APIs**

- avm.getAddressTxs
- avm.getBalance
- avm.getAllBalances
- avm.createAsset
- avm.createFixedCapAsset
- avm.createVariableCapAsset
- avm.createNFTAsset
- avm.createAddress
- avm.listAddresses
- avm.exportKey
- avm.importKey
- avm.mint
- avm.sendNFT
- avm.mintNFT
- avm.import
- avm.export
- avm.send
- avm.sendMultiple

**Deprecated platformvm APIs**

- platform.exportKey
- platform.importKey
- platform.getBalance
- platform.createAddress
- platform.listAddresses
- platform.getSubnets
- platform.addValidator
- platform.addDelegator
- platform.addSubnetValidator
- platform.createSubnet
- platform.exportAVAX
- platform.importAVAX
- platform.createBlockchain
- platform.getBlockchains
- platform.getStake
- platform.getMaxStakeAmount
- platform.getRewardUTXOs

## Env Vars

- `xchainBlockID`
- `xhcainBlockHeight`